### PR TITLE
Add PostgreSQL Monitor Resource

### DIFF
--- a/internal/provider/provider.go
+++ b/internal/provider/provider.go
@@ -104,6 +104,7 @@ func (p *UptimeKumaProvider) Resources(ctx context.Context) []func() resource.Re
 		NewMonitorDNSResource,
 		NewMonitorPushResource,
 		NewMonitorRealBrowserResource,
+		NewMonitorPostgresResource,
 	}
 }
 

--- a/internal/provider/resource_monitor_postgres.go
+++ b/internal/provider/resource_monitor_postgres.go
@@ -1,0 +1,251 @@
+package provider
+
+import (
+	"context"
+	"fmt"
+
+	"github.com/hashicorp/terraform-plugin-framework/resource"
+	"github.com/hashicorp/terraform-plugin-framework/resource/schema"
+	"github.com/hashicorp/terraform-plugin-framework/resource/schema/stringdefault"
+	"github.com/hashicorp/terraform-plugin-framework/types"
+
+	kuma "github.com/breml/go-uptime-kuma-client"
+	"github.com/breml/go-uptime-kuma-client/monitor"
+)
+
+var _ resource.Resource = &MonitorPostgresResource{}
+
+func NewMonitorPostgresResource() resource.Resource {
+	return &MonitorPostgresResource{}
+}
+
+type MonitorPostgresResource struct {
+	client *kuma.Client
+}
+
+type MonitorPostgresResourceModel struct {
+	MonitorBaseModel
+	DatabaseConnectionString types.String `tfsdk:"database_connection_string"`
+	DatabaseQuery            types.String `tfsdk:"database_query"`
+}
+
+func (r *MonitorPostgresResource) Metadata(ctx context.Context, req resource.MetadataRequest, resp *resource.MetadataResponse) {
+	resp.TypeName = req.ProviderTypeName + "_monitor_postgres"
+}
+
+func (r *MonitorPostgresResource) Schema(ctx context.Context, req resource.SchemaRequest, resp *resource.SchemaResponse) {
+	resp.Schema = schema.Schema{
+		MarkdownDescription: "PostgreSQL monitor resource",
+		Attributes: withMonitorBaseAttributes(map[string]schema.Attribute{
+			"database_connection_string": schema.StringAttribute{
+				MarkdownDescription: "PostgreSQL connection string (e.g., postgres://username:password@host:port/database)",
+				Required:            true,
+				Sensitive:           true,
+			},
+			"database_query": schema.StringAttribute{
+				MarkdownDescription: "SQL query to execute for health check",
+				Optional:            true,
+				Computed:            true,
+				Default:             stringdefault.StaticString("SELECT 1"),
+			},
+		}),
+	}
+}
+
+func (r *MonitorPostgresResource) Configure(ctx context.Context, req resource.ConfigureRequest, resp *resource.ConfigureResponse) {
+	if req.ProviderData == nil {
+		return
+	}
+
+	client, ok := req.ProviderData.(*kuma.Client)
+
+	if !ok {
+		resp.Diagnostics.AddError(
+			"Unexpected Resource Configure Type",
+			fmt.Sprintf("Expected *kuma.Client, got: %T. Please report this issue to the provider developers.", req.ProviderData),
+		)
+
+		return
+	}
+
+	r.client = client
+}
+
+func (r *MonitorPostgresResource) Create(ctx context.Context, req resource.CreateRequest, resp *resource.CreateResponse) {
+	var data MonitorPostgresResourceModel
+
+	resp.Diagnostics.Append(req.Plan.Get(ctx, &data)...)
+
+	if resp.Diagnostics.HasError() {
+		return
+	}
+
+	postgresMonitor := monitor.Postgres{
+		Base: monitor.Base{
+			Name:           data.Name.ValueString(),
+			Interval:       data.Interval.ValueInt64(),
+			RetryInterval:  data.RetryInterval.ValueInt64(),
+			ResendInterval: data.ResendInterval.ValueInt64(),
+			MaxRetries:     data.MaxRetries.ValueInt64(),
+			UpsideDown:     data.UpsideDown.ValueBool(),
+			IsActive:       data.Active.ValueBool(),
+		},
+		PostgresDetails: monitor.PostgresDetails{
+			DatabaseConnectionString: data.DatabaseConnectionString.ValueString(),
+			DatabaseQuery:            data.DatabaseQuery.ValueString(),
+		},
+	}
+
+	if !data.Description.IsNull() {
+		desc := data.Description.ValueString()
+		postgresMonitor.Description = &desc
+	}
+
+	if !data.Parent.IsNull() {
+		parent := data.Parent.ValueInt64()
+		postgresMonitor.Parent = &parent
+	}
+
+	if !data.NotificationIDs.IsNull() {
+		var notificationIDs []int64
+		resp.Diagnostics.Append(data.NotificationIDs.ElementsAs(ctx, &notificationIDs, false)...)
+		if resp.Diagnostics.HasError() {
+			return
+		}
+
+		postgresMonitor.NotificationIDs = notificationIDs
+	}
+
+	id, err := r.client.CreateMonitor(ctx, postgresMonitor)
+	if err != nil {
+		resp.Diagnostics.AddError("failed to create PostgreSQL monitor", err.Error())
+		return
+	}
+
+	data.ID = types.Int64Value(id)
+
+	resp.Diagnostics.Append(resp.State.Set(ctx, &data)...)
+}
+
+func (r *MonitorPostgresResource) Read(ctx context.Context, req resource.ReadRequest, resp *resource.ReadResponse) {
+	var data MonitorPostgresResourceModel
+
+	resp.Diagnostics.Append(req.State.Get(ctx, &data)...)
+
+	if resp.Diagnostics.HasError() {
+		return
+	}
+
+	var postgresMonitor monitor.Postgres
+	err := r.client.GetMonitorAs(ctx, data.ID.ValueInt64(), &postgresMonitor)
+	if err != nil {
+		resp.Diagnostics.AddError("failed to read PostgreSQL monitor", err.Error())
+		return
+	}
+
+	data.Name = types.StringValue(postgresMonitor.Name)
+	if postgresMonitor.Description != nil {
+		data.Description = types.StringValue(*postgresMonitor.Description)
+	} else {
+		data.Description = types.StringNull()
+	}
+
+	data.Interval = types.Int64Value(postgresMonitor.Interval)
+	data.RetryInterval = types.Int64Value(postgresMonitor.RetryInterval)
+	data.ResendInterval = types.Int64Value(postgresMonitor.ResendInterval)
+	data.MaxRetries = types.Int64Value(postgresMonitor.MaxRetries)
+	data.UpsideDown = types.BoolValue(postgresMonitor.UpsideDown)
+	data.Active = types.BoolValue(postgresMonitor.IsActive)
+	data.DatabaseConnectionString = types.StringValue(postgresMonitor.DatabaseConnectionString)
+	data.DatabaseQuery = types.StringValue(postgresMonitor.DatabaseQuery)
+
+	if postgresMonitor.Parent != nil {
+		data.Parent = types.Int64Value(*postgresMonitor.Parent)
+	} else {
+		data.Parent = types.Int64Null()
+	}
+
+	if len(postgresMonitor.NotificationIDs) > 0 {
+		notificationIDs, diags := types.ListValueFrom(ctx, types.Int64Type, postgresMonitor.NotificationIDs)
+		resp.Diagnostics.Append(diags...)
+		if resp.Diagnostics.HasError() {
+			return
+		}
+
+		data.NotificationIDs = notificationIDs
+	} else {
+		data.NotificationIDs = types.ListNull(types.Int64Type)
+	}
+
+	resp.Diagnostics.Append(resp.State.Set(ctx, &data)...)
+}
+
+func (r *MonitorPostgresResource) Update(ctx context.Context, req resource.UpdateRequest, resp *resource.UpdateResponse) {
+	var data MonitorPostgresResourceModel
+
+	resp.Diagnostics.Append(req.Plan.Get(ctx, &data)...)
+	if resp.Diagnostics.HasError() {
+		return
+	}
+
+	postgresMonitor := monitor.Postgres{
+		Base: monitor.Base{
+			ID:             data.ID.ValueInt64(),
+			Name:           data.Name.ValueString(),
+			Interval:       data.Interval.ValueInt64(),
+			RetryInterval:  data.RetryInterval.ValueInt64(),
+			ResendInterval: data.ResendInterval.ValueInt64(),
+			MaxRetries:     data.MaxRetries.ValueInt64(),
+			UpsideDown:     data.UpsideDown.ValueBool(),
+			IsActive:       data.Active.ValueBool(),
+		},
+		PostgresDetails: monitor.PostgresDetails{
+			DatabaseConnectionString: data.DatabaseConnectionString.ValueString(),
+			DatabaseQuery:            data.DatabaseQuery.ValueString(),
+		},
+	}
+
+	if !data.Description.IsNull() {
+		desc := data.Description.ValueString()
+		postgresMonitor.Description = &desc
+	}
+
+	if !data.Parent.IsNull() {
+		parent := data.Parent.ValueInt64()
+		postgresMonitor.Parent = &parent
+	}
+
+	if !data.NotificationIDs.IsNull() {
+		var notificationIDs []int64
+		resp.Diagnostics.Append(data.NotificationIDs.ElementsAs(ctx, &notificationIDs, false)...)
+		if resp.Diagnostics.HasError() {
+			return
+		}
+
+		postgresMonitor.NotificationIDs = notificationIDs
+	}
+
+	err := r.client.UpdateMonitor(ctx, postgresMonitor)
+	if err != nil {
+		resp.Diagnostics.AddError("failed to update PostgreSQL monitor", err.Error())
+		return
+	}
+
+	resp.Diagnostics.Append(resp.State.Set(ctx, &data)...)
+}
+
+func (r *MonitorPostgresResource) Delete(ctx context.Context, req resource.DeleteRequest, resp *resource.DeleteResponse) {
+	var data MonitorPostgresResourceModel
+
+	resp.Diagnostics.Append(req.State.Get(ctx, &data)...)
+
+	if resp.Diagnostics.HasError() {
+		return
+	}
+
+	err := r.client.DeleteMonitor(ctx, data.ID.ValueInt64())
+	if err != nil {
+		resp.Diagnostics.AddError("failed to delete PostgreSQL monitor", err.Error())
+		return
+	}
+}

--- a/internal/provider/resource_monitor_postgres_test.go
+++ b/internal/provider/resource_monitor_postgres_test.go
@@ -1,0 +1,137 @@
+package provider
+
+import (
+	"fmt"
+	"testing"
+
+	"github.com/hashicorp/terraform-plugin-testing/helper/acctest"
+	"github.com/hashicorp/terraform-plugin-testing/helper/resource"
+	"github.com/hashicorp/terraform-plugin-testing/knownvalue"
+	"github.com/hashicorp/terraform-plugin-testing/statecheck"
+	"github.com/hashicorp/terraform-plugin-testing/tfjsonpath"
+)
+
+func TestAccMonitorPostgresResource(t *testing.T) {
+	name := acctest.RandomWithPrefix("TestPostgresMonitor")
+	nameUpdated := acctest.RandomWithPrefix("TestPostgresMonitorUpdated")
+	connectionString := "postgres://user:password@localhost:5432/testdb"
+
+	resource.Test(t, resource.TestCase{
+		PreCheck:                 func() { testAccPreCheck(t) },
+		ProtoV6ProviderFactories: testAccProtoV6ProviderFactories,
+		Steps: []resource.TestStep{
+			{
+				Config:             testAccMonitorPostgresResourceConfig(name, connectionString, "SELECT 1"),
+				ExpectNonEmptyPlan: false,
+				ConfigStateChecks: []statecheck.StateCheck{
+					statecheck.ExpectKnownValue("uptimekuma_monitor_postgres.test", tfjsonpath.New("name"), knownvalue.StringExact(name)),
+					statecheck.ExpectKnownValue("uptimekuma_monitor_postgres.test", tfjsonpath.New("database_connection_string"), knownvalue.StringExact(connectionString)),
+					statecheck.ExpectKnownValue("uptimekuma_monitor_postgres.test", tfjsonpath.New("database_query"), knownvalue.StringExact("SELECT 1")),
+					statecheck.ExpectKnownValue("uptimekuma_monitor_postgres.test", tfjsonpath.New("interval"), knownvalue.Int64Exact(60)),
+					statecheck.ExpectKnownValue("uptimekuma_monitor_postgres.test", tfjsonpath.New("active"), knownvalue.Bool(true)),
+				},
+			},
+			{
+				Config: testAccMonitorPostgresResourceConfig(nameUpdated, connectionString, "SELECT version()"),
+				ConfigStateChecks: []statecheck.StateCheck{
+					statecheck.ExpectKnownValue("uptimekuma_monitor_postgres.test", tfjsonpath.New("name"), knownvalue.StringExact(nameUpdated)),
+					statecheck.ExpectKnownValue("uptimekuma_monitor_postgres.test", tfjsonpath.New("database_connection_string"), knownvalue.StringExact(connectionString)),
+					statecheck.ExpectKnownValue("uptimekuma_monitor_postgres.test", tfjsonpath.New("database_query"), knownvalue.StringExact("SELECT version()")),
+					statecheck.ExpectKnownValue("uptimekuma_monitor_postgres.test", tfjsonpath.New("active"), knownvalue.Bool(true)),
+				},
+			},
+		},
+	})
+}
+
+func testAccMonitorPostgresResourceConfig(name, connectionString, query string) string {
+	return providerConfig() + fmt.Sprintf(`
+resource "uptimekuma_monitor_postgres" "test" {
+  name                        = %[1]q
+  database_connection_string  = %[2]q
+  database_query              = %[3]q
+  interval                    = 60
+  active                      = true
+}
+`, name, connectionString, query)
+}
+
+func TestAccMonitorPostgresResourceWithOptionalFields(t *testing.T) {
+	name := acctest.RandomWithPrefix("TestPostgresMonitorWithOptional")
+	description := "Test PostgreSQL monitor with optional fields"
+	connectionString := "postgres://user:password@localhost:5432/testdb"
+
+	resource.Test(t, resource.TestCase{
+		PreCheck:                 func() { testAccPreCheck(t) },
+		ProtoV6ProviderFactories: testAccProtoV6ProviderFactories,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccMonitorPostgresResourceConfigWithOptionalFields(name, description, connectionString),
+				ConfigStateChecks: []statecheck.StateCheck{
+					statecheck.ExpectKnownValue("uptimekuma_monitor_postgres.test", tfjsonpath.New("name"), knownvalue.StringExact(name)),
+					statecheck.ExpectKnownValue("uptimekuma_monitor_postgres.test", tfjsonpath.New("description"), knownvalue.StringExact(description)),
+					statecheck.ExpectKnownValue("uptimekuma_monitor_postgres.test", tfjsonpath.New("database_connection_string"), knownvalue.StringExact(connectionString)),
+					statecheck.ExpectKnownValue("uptimekuma_monitor_postgres.test", tfjsonpath.New("database_query"), knownvalue.StringExact("SELECT 1")),
+					statecheck.ExpectKnownValue("uptimekuma_monitor_postgres.test", tfjsonpath.New("interval"), knownvalue.Int64Exact(60)),
+					statecheck.ExpectKnownValue("uptimekuma_monitor_postgres.test", tfjsonpath.New("retry_interval"), knownvalue.Int64Exact(60)),
+					statecheck.ExpectKnownValue("uptimekuma_monitor_postgres.test", tfjsonpath.New("resend_interval"), knownvalue.Int64Exact(0)),
+					statecheck.ExpectKnownValue("uptimekuma_monitor_postgres.test", tfjsonpath.New("max_retries"), knownvalue.Int64Exact(3)),
+					statecheck.ExpectKnownValue("uptimekuma_monitor_postgres.test", tfjsonpath.New("upside_down"), knownvalue.Bool(false)),
+					statecheck.ExpectKnownValue("uptimekuma_monitor_postgres.test", tfjsonpath.New("active"), knownvalue.Bool(true)),
+				},
+			},
+		},
+	})
+}
+
+func testAccMonitorPostgresResourceConfigWithOptionalFields(name, description, connectionString string) string {
+	return providerConfig() + fmt.Sprintf(`
+resource "uptimekuma_monitor_postgres" "test" {
+  name                       = %[1]q
+  description                = %[2]q
+  database_connection_string = %[3]q
+  interval                   = 60
+  retry_interval             = 60
+  resend_interval            = 0
+  max_retries                = 3
+  upside_down                = false
+  active                     = true
+}
+`, name, description, connectionString)
+}
+
+func TestAccMonitorPostgresResourceWithParent(t *testing.T) {
+	groupName := acctest.RandomWithPrefix("TestPostgresGroup")
+	monitorName := acctest.RandomWithPrefix("TestPostgresMonitorWithParent")
+	connectionString := "postgres://user:password@localhost:5432/testdb"
+
+	resource.Test(t, resource.TestCase{
+		PreCheck:                 func() { testAccPreCheck(t) },
+		ProtoV6ProviderFactories: testAccProtoV6ProviderFactories,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccMonitorPostgresResourceConfigWithParent(groupName, monitorName, connectionString),
+				ConfigStateChecks: []statecheck.StateCheck{
+					statecheck.ExpectKnownValue("uptimekuma_monitor_group.test", tfjsonpath.New("name"), knownvalue.StringExact(groupName)),
+					statecheck.ExpectKnownValue("uptimekuma_monitor_postgres.test", tfjsonpath.New("name"), knownvalue.StringExact(monitorName)),
+					statecheck.ExpectKnownValue("uptimekuma_monitor_postgres.test", tfjsonpath.New("parent"), knownvalue.NotNull()),
+					statecheck.ExpectKnownValue("uptimekuma_monitor_postgres.test", tfjsonpath.New("database_connection_string"), knownvalue.StringExact(connectionString)),
+				},
+			},
+		},
+	})
+}
+
+func testAccMonitorPostgresResourceConfigWithParent(groupName, monitorName, connectionString string) string {
+	return providerConfig() + fmt.Sprintf(`
+resource "uptimekuma_monitor_group" "test" {
+  name = %[1]q
+}
+
+resource "uptimekuma_monitor_postgres" "test" {
+  name                       = %[2]q
+  database_connection_string = %[3]q
+  parent                     = uptimekuma_monitor_group.test.id
+}
+`, groupName, monitorName, connectionString)
+}


### PR DESCRIPTION
## Summary

Implements PostgreSQL monitor resource support for the Uptime Kuma Terraform provider, enabling users to monitor PostgreSQL databases via Terraform.

## Changes

- **New Resource**: `uptimekuma_monitor_postgres`
  - PostgreSQL connection string configuration (marked as sensitive)
  - Customizable database query (defaults to "SELECT 1")
  - Full CRUD operations (Create, Read, Update, Delete)
  - All standard monitor base attributes (interval, retry_interval, max_retries, etc.)
  - Support for parent/child monitor hierarchy via `parent` field
  
- **Implementation**:
  - Uses `monitor.Postgres` from go-uptime-kuma-client library
  - Follows existing monitor resource patterns (HTTP, Push, Ping, etc.)
  - Schema includes:
    - `database_connection_string` (required, sensitive)
    - `database_query` (optional, defaults to "SELECT 1")
    - All base monitor attributes

- **Tests**:
  - Basic resource creation and update
  - Optional fields configuration
  - Parent/child relationships
  - All tests follow the existing test patterns

## Implementation Details

The implementation follows the established patterns in the codebase:

1. Resource file: `internal/provider/resource_monitor_postgres.go`
2. Test file: `internal/provider/resource_monitor_postgres_test.go`
3. Updated `internal/provider/provider.go` to register the new resource
4. Documentation generated via `make generate`

## Test Plan

- [x] Code formatted (`make fmt`)
- [x] Code linted (`make lint`)
- [x] Unit tests pass (`make test`)
- [ ] Acceptance tests pass (`make testacc`) - requires Uptime Kuma instance

## Example Usage

```hcl
resource "uptimekuma_monitor_postgres" "example" {
  name                       = "Production Database"
  description                = "Monitor production PostgreSQL database"
  database_connection_string = "postgres://user:password@localhost:5432/mydb"
  database_query             = "SELECT 1"
  interval                   = 60
  active                     = true
}
```

Closes #9

🤖 Generated with [Claude Code](https://claude.com/claude-code)