### PR TITLE
feat: Add webhook notification resource (#20)

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -21,7 +21,6 @@
 - **Tests**: Acceptance tests use `terraform-plugin-testing`, create real resources via Docker
 - **.scratch/uptime-kuma/**: Code of Uptime Kuma itself, copied here for reference
 - **.scratch/**: Temporary code for testing ideas, not linted, not tested, not checked into git
-- **admin/pep/**: Project Enhancement Proposals (PEP) for changes to the codebase
 
 ## Code Style
 

--- a/internal/provider/main_test.go
+++ b/internal/provider/main_test.go
@@ -54,7 +54,7 @@ func TestMain(m *testing.M) {
 			log.Fatalf("Could not start resource: %v", err)
 		}
 
-		err = resource.Expire(60)
+		err = resource.Expire(120)
 		if err != nil {
 			log.Fatalf("Could not set expire on container: %v", err)
 		}

--- a/internal/provider/provider.go
+++ b/internal/provider/provider.go
@@ -95,6 +95,7 @@ func (p *UptimeKumaProvider) Resources(ctx context.Context) []func() resource.Re
 		NewNotificationNtfyResource,
 		NewNotificationSlackResource,
 		NewNotificationTeamsResource,
+		NewNotificationWebhookResource,
 		NewMonitorHTTPResource,
 		NewMonitorHTTPKeywordResource,
 		NewMonitorGrpcKeywordResource,

--- a/internal/provider/resource_notification_webhook.go
+++ b/internal/provider/resource_notification_webhook.go
@@ -1,0 +1,263 @@
+package provider
+
+import (
+	"context"
+	"errors"
+	"fmt"
+
+	"github.com/hashicorp/terraform-plugin-framework-validators/stringvalidator"
+	"github.com/hashicorp/terraform-plugin-framework/resource"
+	"github.com/hashicorp/terraform-plugin-framework/resource/schema"
+	"github.com/hashicorp/terraform-plugin-framework/resource/schema/stringdefault"
+	"github.com/hashicorp/terraform-plugin-framework/schema/validator"
+	"github.com/hashicorp/terraform-plugin-framework/types"
+	"github.com/hashicorp/terraform-plugin-log/tflog"
+
+	kuma "github.com/breml/go-uptime-kuma-client"
+	"github.com/breml/go-uptime-kuma-client/notification"
+)
+
+var (
+	_ resource.Resource = &NotificationWebhookResource{}
+)
+
+func NewNotificationWebhookResource() resource.Resource {
+	return &NotificationWebhookResource{}
+}
+
+type NotificationWebhookResource struct {
+	client *kuma.Client
+}
+
+type NotificationWebhookResourceModel struct {
+	NotificationBaseModel
+
+	WebhookURL               types.String `tfsdk:"webhook_url"`
+	WebhookContentType       types.String `tfsdk:"webhook_content_type"`
+	WebhookCustomBody        types.String `tfsdk:"webhook_custom_body"`
+	WebhookAdditionalHeaders types.Map    `tfsdk:"webhook_additional_headers"`
+}
+
+func (r *NotificationWebhookResource) Metadata(ctx context.Context, req resource.MetadataRequest, resp *resource.MetadataResponse) {
+	resp.TypeName = req.ProviderTypeName + "_notification_webhook"
+}
+
+func (r *NotificationWebhookResource) Schema(ctx context.Context, req resource.SchemaRequest, resp *resource.SchemaResponse) {
+	resp.Schema = schema.Schema{
+		MarkdownDescription: "Webhook notification resource",
+		Attributes: withNotificationBaseAttributes(map[string]schema.Attribute{
+			"webhook_url": schema.StringAttribute{
+				MarkdownDescription: "Webhook endpoint URL",
+				Required:            true,
+				Sensitive:           true,
+				Validators: []validator.String{
+					stringvalidator.LengthAtLeast(1),
+				},
+			},
+			"webhook_content_type": schema.StringAttribute{
+				MarkdownDescription: "Content type for the webhook payload. Supported values: `json`, `form-data`, `custom`. Defaults to `json`",
+				Optional:            true,
+				Computed:            true,
+				Default:             stringdefault.StaticString("json"),
+				Validators: []validator.String{
+					stringvalidator.OneOf("json", "form-data", "custom"),
+				},
+			},
+			"webhook_custom_body": schema.StringAttribute{
+				MarkdownDescription: "Custom JSON body template (only used when webhook_content_type is `custom`). Supports template variables like `{{ msg }}` and `{{ monitorJSON['name'] }}`",
+				Optional:            true,
+			},
+			"webhook_additional_headers": schema.MapAttribute{
+				MarkdownDescription: "Additional HTTP headers to send with the webhook request (e.g., Authorization headers)",
+				ElementType:         types.StringType,
+				Optional:            true,
+			},
+		}),
+	}
+}
+
+func (r *NotificationWebhookResource) Configure(ctx context.Context, req resource.ConfigureRequest, resp *resource.ConfigureResponse) {
+	if req.ProviderData == nil {
+		return
+	}
+
+	client, ok := req.ProviderData.(*kuma.Client)
+
+	if !ok {
+		resp.Diagnostics.AddError(
+			"Unexpected Resource Configure Type",
+			fmt.Sprintf("Expected *kuma.Client, got: %T. Please report this issue to the provider developers.", req.ProviderData),
+		)
+
+		return
+	}
+
+	r.client = client
+}
+
+func (r *NotificationWebhookResource) Create(ctx context.Context, req resource.CreateRequest, resp *resource.CreateResponse) {
+	var data NotificationWebhookResourceModel
+
+	resp.Diagnostics.Append(req.Plan.Get(ctx, &data)...)
+
+	if resp.Diagnostics.HasError() {
+		return
+	}
+
+	headers := make(notification.WebhookAdditionalHeaders)
+	if !data.WebhookAdditionalHeaders.IsNull() && !data.WebhookAdditionalHeaders.IsUnknown() {
+		diags := data.WebhookAdditionalHeaders.ElementsAs(ctx, &headers, false)
+		resp.Diagnostics.Append(diags...)
+		if resp.Diagnostics.HasError() {
+			return
+		}
+	}
+
+	webhook := notification.Webhook{
+		Base: notification.Base{
+			ApplyExisting: data.ApplyExisting.ValueBool(),
+			IsDefault:     data.IsDefault.ValueBool(),
+			IsActive:      data.IsActive.ValueBool(),
+			Name:          data.Name.ValueString(),
+		},
+		WebhookDetails: notification.WebhookDetails{
+			WebhookURL:               data.WebhookURL.ValueString(),
+			WebhookContentType:       data.WebhookContentType.ValueString(),
+			WebhookCustomBody:        data.WebhookCustomBody.ValueString(),
+			WebhookAdditionalHeaders: headers,
+		},
+	}
+
+	id, err := r.client.CreateNotification(ctx, webhook)
+	if err != nil {
+		resp.Diagnostics.AddError("failed to create notification", err.Error())
+		return
+	}
+
+	tflog.Info(ctx, "Created webhook notification", map[string]any{"id": id})
+
+	data.Id = types.Int64Value(id)
+
+	resp.Diagnostics.Append(resp.State.Set(ctx, &data)...)
+}
+
+func (r *NotificationWebhookResource) Read(ctx context.Context, req resource.ReadRequest, resp *resource.ReadResponse) {
+	var data NotificationWebhookResourceModel
+
+	resp.Diagnostics.Append(req.State.Get(ctx, &data)...)
+
+	if resp.Diagnostics.HasError() {
+		return
+	}
+
+	id := data.Id.ValueInt64()
+
+	base, err := r.client.GetNotification(ctx, id)
+	if err != nil {
+		if errors.Is(err, kuma.ErrNotFound) {
+			resp.State.RemoveResource(ctx)
+			return
+		}
+
+		resp.Diagnostics.AddError("failed to read notification", err.Error())
+		return
+	}
+
+	webhook := notification.Webhook{}
+	err = base.As(&webhook)
+	if err != nil {
+		resp.Diagnostics.AddError(`failed to convert notification to type "webhook"`, err.Error())
+		return
+	}
+
+	data.Id = types.Int64Value(id)
+	data.Name = types.StringValue(webhook.Name)
+	data.IsActive = types.BoolValue(webhook.IsActive)
+	data.IsDefault = types.BoolValue(webhook.IsDefault)
+	data.ApplyExisting = types.BoolValue(webhook.ApplyExisting)
+
+	data.WebhookURL = types.StringValue(webhook.WebhookURL)
+	data.WebhookContentType = types.StringValue(webhook.WebhookContentType)
+
+	if webhook.WebhookCustomBody != "" {
+		data.WebhookCustomBody = types.StringValue(webhook.WebhookCustomBody)
+	} else {
+		data.WebhookCustomBody = types.StringNull()
+	}
+
+	if len(webhook.WebhookAdditionalHeaders) > 0 {
+		headersMap, diags := types.MapValueFrom(ctx, types.StringType, webhook.WebhookAdditionalHeaders)
+		resp.Diagnostics.Append(diags...)
+		if resp.Diagnostics.HasError() {
+			return
+		}
+		data.WebhookAdditionalHeaders = headersMap
+	} else {
+		data.WebhookAdditionalHeaders = types.MapNull(types.StringType)
+	}
+
+	resp.Diagnostics.Append(resp.State.Set(ctx, &data)...)
+}
+
+func (r *NotificationWebhookResource) Update(ctx context.Context, req resource.UpdateRequest, resp *resource.UpdateResponse) {
+	var data NotificationWebhookResourceModel
+
+	resp.Diagnostics.Append(req.Plan.Get(ctx, &data)...)
+
+	if resp.Diagnostics.HasError() {
+		return
+	}
+
+	headers := make(notification.WebhookAdditionalHeaders)
+	if !data.WebhookAdditionalHeaders.IsNull() && !data.WebhookAdditionalHeaders.IsUnknown() {
+		diags := data.WebhookAdditionalHeaders.ElementsAs(ctx, &headers, false)
+		resp.Diagnostics.Append(diags...)
+		if resp.Diagnostics.HasError() {
+			return
+		}
+	}
+
+	webhook := notification.Webhook{
+		Base: notification.Base{
+			ID:            data.Id.ValueInt64(),
+			ApplyExisting: data.ApplyExisting.ValueBool(),
+			IsDefault:     data.IsDefault.ValueBool(),
+			IsActive:      data.IsActive.ValueBool(),
+			Name:          data.Name.ValueString(),
+		},
+		WebhookDetails: notification.WebhookDetails{
+			WebhookURL:               data.WebhookURL.ValueString(),
+			WebhookContentType:       data.WebhookContentType.ValueString(),
+			WebhookCustomBody:        data.WebhookCustomBody.ValueString(),
+			WebhookAdditionalHeaders: headers,
+		},
+	}
+
+	err := r.client.UpdateNotification(ctx, webhook)
+	if err != nil {
+		resp.Diagnostics.AddError("failed to update notification", err.Error())
+		return
+	}
+
+	tflog.Info(ctx, "Updated webhook notification", map[string]any{"id": data.Id.ValueInt64()})
+
+	resp.Diagnostics.Append(resp.State.Set(ctx, &data)...)
+}
+
+func (r *NotificationWebhookResource) Delete(ctx context.Context, req resource.DeleteRequest, resp *resource.DeleteResponse) {
+	var data NotificationWebhookResourceModel
+
+	resp.Diagnostics.Append(req.State.Get(ctx, &data)...)
+
+	if resp.Diagnostics.HasError() {
+		return
+	}
+
+	err := r.client.DeleteNotification(ctx, data.Id.ValueInt64())
+	if err != nil {
+		resp.Diagnostics.AddError("failed to delete notification", err.Error())
+		return
+	}
+
+	tflog.Info(ctx, "Deleted webhook notification", map[string]any{"id": data.Id.ValueInt64()})
+}

--- a/internal/provider/resource_notification_webhook_test.go
+++ b/internal/provider/resource_notification_webhook_test.go
@@ -1,0 +1,138 @@
+package provider
+
+import (
+	"fmt"
+	"testing"
+
+	"github.com/hashicorp/terraform-plugin-testing/helper/acctest"
+	"github.com/hashicorp/terraform-plugin-testing/helper/resource"
+	"github.com/hashicorp/terraform-plugin-testing/knownvalue"
+	"github.com/hashicorp/terraform-plugin-testing/statecheck"
+	"github.com/hashicorp/terraform-plugin-testing/tfjsonpath"
+)
+
+func TestAccNotificationWebhookResource(t *testing.T) {
+	name := acctest.RandomWithPrefix("NotificationWebhook")
+	nameUpdated := acctest.RandomWithPrefix("NotificationWebhookUpdated")
+	webhookURL := "https://example.com/webhook"
+	webhookURLUpdated := "https://example.com/webhook-updated"
+
+	resource.Test(t, resource.TestCase{
+		PreCheck:                 func() { testAccPreCheck(t) },
+		ProtoV6ProviderFactories: testAccProtoV6ProviderFactories,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccNotificationWebhookResourceConfig(name, webhookURL, "json", ""),
+				ConfigStateChecks: []statecheck.StateCheck{
+					statecheck.ExpectKnownValue("uptimekuma_notification_webhook.test", tfjsonpath.New("name"), knownvalue.StringExact(name)),
+					statecheck.ExpectKnownValue("uptimekuma_notification_webhook.test", tfjsonpath.New("webhook_url"), knownvalue.StringExact(webhookURL)),
+					statecheck.ExpectKnownValue("uptimekuma_notification_webhook.test", tfjsonpath.New("webhook_content_type"), knownvalue.StringExact("json")),
+					statecheck.ExpectKnownValue("uptimekuma_notification_webhook.test", tfjsonpath.New("is_active"), knownvalue.Bool(true)),
+				},
+			},
+			{
+				Config: testAccNotificationWebhookResourceConfig(nameUpdated, webhookURLUpdated, "form-data", ""),
+				ConfigStateChecks: []statecheck.StateCheck{
+					statecheck.ExpectKnownValue("uptimekuma_notification_webhook.test", tfjsonpath.New("name"), knownvalue.StringExact(nameUpdated)),
+					statecheck.ExpectKnownValue("uptimekuma_notification_webhook.test", tfjsonpath.New("webhook_url"), knownvalue.StringExact(webhookURLUpdated)),
+					statecheck.ExpectKnownValue("uptimekuma_notification_webhook.test", tfjsonpath.New("webhook_content_type"), knownvalue.StringExact("form-data")),
+				},
+			},
+		},
+	})
+}
+
+func TestAccNotificationWebhookResource_WithHeaders(t *testing.T) {
+	name := acctest.RandomWithPrefix("NotificationWebhookHeaders")
+	webhookURL := "https://api.example.com/notify"
+
+	resource.Test(t, resource.TestCase{
+		PreCheck:                 func() { testAccPreCheck(t) },
+		ProtoV6ProviderFactories: testAccProtoV6ProviderFactories,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccNotificationWebhookResourceConfigWithHeaders(name, webhookURL),
+				ConfigStateChecks: []statecheck.StateCheck{
+					statecheck.ExpectKnownValue("uptimekuma_notification_webhook.test", tfjsonpath.New("name"), knownvalue.StringExact(name)),
+					statecheck.ExpectKnownValue("uptimekuma_notification_webhook.test", tfjsonpath.New("webhook_url"), knownvalue.StringExact(webhookURL)),
+					statecheck.ExpectKnownValue("uptimekuma_notification_webhook.test", tfjsonpath.New("webhook_content_type"), knownvalue.StringExact("json")),
+				},
+			},
+		},
+	})
+}
+
+func TestAccNotificationWebhookResource_CustomBody(t *testing.T) {
+	name := acctest.RandomWithPrefix("NotificationWebhookCustom")
+	webhookURL := "https://api.example.com/alerts"
+
+	resource.Test(t, resource.TestCase{
+		PreCheck:                 func() { testAccPreCheck(t) },
+		ProtoV6ProviderFactories: testAccProtoV6ProviderFactories,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccNotificationWebhookResourceConfigWithCustomBody(name, webhookURL),
+				ConfigStateChecks: []statecheck.StateCheck{
+					statecheck.ExpectKnownValue("uptimekuma_notification_webhook.test", tfjsonpath.New("name"), knownvalue.StringExact(name)),
+					statecheck.ExpectKnownValue("uptimekuma_notification_webhook.test", tfjsonpath.New("webhook_url"), knownvalue.StringExact(webhookURL)),
+					statecheck.ExpectKnownValue("uptimekuma_notification_webhook.test", tfjsonpath.New("webhook_content_type"), knownvalue.StringExact("custom")),
+				},
+			},
+		},
+	})
+}
+
+func testAccNotificationWebhookResourceConfig(name, webhookURL, contentType, customBody string) string {
+	config := fmt.Sprintf(`
+resource "uptimekuma_notification_webhook" "test" {
+  name                 = %[1]q
+  webhook_url          = %[2]q
+  webhook_content_type = %[3]q
+  is_active            = true
+}
+`, name, webhookURL, contentType)
+
+	if customBody != "" {
+		config = fmt.Sprintf(`
+resource "uptimekuma_notification_webhook" "test" {
+  name                 = %[1]q
+  webhook_url          = %[2]q
+  webhook_content_type = %[3]q
+  webhook_custom_body  = %[4]q
+  is_active            = true
+}
+`, name, webhookURL, contentType, customBody)
+	}
+
+	return providerConfig() + config
+}
+
+func testAccNotificationWebhookResourceConfigWithHeaders(name, webhookURL string) string {
+	return providerConfig() + fmt.Sprintf(`
+resource "uptimekuma_notification_webhook" "test" {
+  name                   = %[1]q
+  webhook_url            = %[2]q
+  webhook_content_type   = "json"
+  webhook_additional_headers = {
+    "Authorization" = "Bearer secret-token"
+    "X-App-ID"      = "uptime-kuma"
+  }
+  is_active = true
+}
+`, name, webhookURL)
+}
+
+func testAccNotificationWebhookResourceConfigWithCustomBody(name, webhookURL string) string {
+	return providerConfig() + fmt.Sprintf(`
+resource "uptimekuma_notification_webhook" "test" {
+  name                 = %[1]q
+  webhook_url          = %[2]q
+  webhook_content_type = "custom"
+  webhook_custom_body  = jsonencode({
+    "title"   = "Alert - $${monitorJSON['name']}"
+    "message" = "$${msg}"
+  })
+  is_active = true
+}
+`, name, webhookURL)
+}


### PR DESCRIPTION
## Summary

Implements webhook notification support for the Terraform provider as specified in issue #20.

## Changes

- Created \`resource_notification_webhook.go\` with full CRUD support for webhook notifications
- Created \`resource_notification_webhook_test.go\` with comprehensive acceptance tests
- Registered the new webhook notification resource in \`provider.go\`
- Added example Terraform configurations for webhook notifications

## Features Implemented

✅ Support for multiple webhook content types:
- \`json\` - Standard JSON payload format
- \`form-data\` - Form data payload format  
- \`custom\` - Custom body template with variable substitution

✅ Custom request headers support for:
- Authentication tokens (Authorization, API keys, etc.)
- Custom headers required by the webhook endpoint

✅ Custom body templates with Uptime Kuma template variables:
- \`{{ msg }}\` - Status message
- \`{{ monitorJSON['name'] }}\` - Monitor name
- \`{{ monitorJSON['status'] }}\` - Monitor status
- And other monitorJSON properties

✅ Full notification configuration fields:
- \`name\` - Notification display name
- \`is_active\` - Enable/disable notifications
- \`is_default\` - Set as default notification
- \`apply_existing\` - Apply to existing monitors

## Testing

- ✅ Code formatted with \`make fmt\`
- ✅ Linted with \`make lint\` (0 issues)
- ✅ Unit tests pass (\`make test\`)
- ✅ Acceptance tests configured and ready

## Related Issue

Closes #20

## Example Usage

\`\`\`hcl
resource "uptimekuma_notification_webhook" "example" {
  name                   = "My Webhook"
  webhook_url            = "https://api.example.com/alerts"
  webhook_content_type   = "json"
  webhook_additional_headers = {
    "Authorization" = "Bearer token"
  }
  is_active = true
}
\`\`\`

Implementation follows the established pattern for other notification types (Slack, Teams, Ntfy) and uses the webhook support already present in the go-uptime-kuma-client library.