### PR TITLE
feat: Add uptimekuma_tag resource

### DIFF
--- a/go.sum
+++ b/go.sum
@@ -15,8 +15,6 @@ github.com/agext/levenshtein v1.2.2/go.mod h1:JEDfjyjHDjOF/1e4FlBE/PkbqA9OfWu2ki
 github.com/apparentlymart/go-textseg/v12 v12.0.0/go.mod h1:S/4uRK2UtaQttw1GenVJEynmyUenKwP++x/+DdGV/Ec=
 github.com/apparentlymart/go-textseg/v15 v15.0.0 h1:uYvfpb3DyLSCGWnctWKGj857c6ew1u1fNQOlOtuGxQY=
 github.com/apparentlymart/go-textseg/v15 v15.0.0/go.mod h1:K8XmNZdhEBkdlyDdvbmmsvpAG721bKi0joRfFdHIWJ4=
-github.com/breml/go-uptime-kuma-client v0.0.0-20251129133020-fae61887ca96 h1:ZnKBn+HwsPu5kcefc/pB2lp5m4QpREowdqABmU8oooc=
-github.com/breml/go-uptime-kuma-client v0.0.0-20251129133020-fae61887ca96/go.mod h1:rrkfME8FRHXjZmngQbsMyv7Pz/9lUdxmKz67lewaXHg=
 github.com/breml/go-uptime-kuma-client v0.0.0-20251129153851-b286e4792aed h1:whv0k7NZcz3siyWraEL7d9VXi+oQf0JrkH2tvdJEOm4=
 github.com/breml/go-uptime-kuma-client v0.0.0-20251129153851-b286e4792aed/go.mod h1:rrkfME8FRHXjZmngQbsMyv7Pz/9lUdxmKz67lewaXHg=
 github.com/bufbuild/protocompile v0.14.1 h1:iA73zAf/fyljNjQKwYzUHD6AD4R8KMasmwa/FBatYVw=

--- a/internal/provider/provider.go
+++ b/internal/provider/provider.go
@@ -108,6 +108,7 @@ func (p *UptimeKumaProvider) Resources(ctx context.Context) []func() resource.Re
 		NewMonitorPostgresResource,
 		NewMonitorRedisResource,
 		NewMonitorTCPPortResource,
+		NewTagResource,
 	}
 }
 

--- a/internal/provider/resource_tag_test.go
+++ b/internal/provider/resource_tag_test.go
@@ -1,0 +1,77 @@
+package provider
+
+import (
+	"fmt"
+	"testing"
+
+	"github.com/hashicorp/terraform-plugin-testing/helper/acctest"
+	"github.com/hashicorp/terraform-plugin-testing/helper/resource"
+	"github.com/hashicorp/terraform-plugin-testing/knownvalue"
+	"github.com/hashicorp/terraform-plugin-testing/statecheck"
+	"github.com/hashicorp/terraform-plugin-testing/tfjsonpath"
+)
+
+func TestAccTagResource(t *testing.T) {
+	name := acctest.RandomWithPrefix("TestTag")
+	nameUpdated := acctest.RandomWithPrefix("TestTagUpdated")
+	color := "#3498db"
+	colorUpdated := "#2ecc71"
+
+	resource.Test(t, resource.TestCase{
+		PreCheck:                 func() { testAccPreCheck(t) },
+		ProtoV6ProviderFactories: testAccProtoV6ProviderFactories,
+		Steps: []resource.TestStep{
+			{
+				Config:             testAccTagResourceConfig(name, color),
+				ExpectNonEmptyPlan: false,
+				ConfigStateChecks: []statecheck.StateCheck{
+					statecheck.ExpectKnownValue("uptimekuma_tag.test", tfjsonpath.New("name"), knownvalue.StringExact(name)),
+					statecheck.ExpectKnownValue("uptimekuma_tag.test", tfjsonpath.New("color"), knownvalue.StringExact(color)),
+				},
+			},
+			{
+				Config:             testAccTagResourceConfig(nameUpdated, colorUpdated),
+				ExpectNonEmptyPlan: false,
+				ConfigStateChecks: []statecheck.StateCheck{
+					statecheck.ExpectKnownValue("uptimekuma_tag.test", tfjsonpath.New("name"), knownvalue.StringExact(nameUpdated)),
+					statecheck.ExpectKnownValue("uptimekuma_tag.test", tfjsonpath.New("color"), knownvalue.StringExact(colorUpdated)),
+				},
+			},
+		},
+	})
+}
+
+func testAccTagResourceConfig(name, color string) string {
+	return providerConfig() + fmt.Sprintf(`
+resource "uptimekuma_tag" "test" {
+  name  = %[1]q
+  color = %[2]q
+}
+`, name, color)
+}
+
+func TestAccTagResourceDelete(t *testing.T) {
+	name := acctest.RandomWithPrefix("TestTagDelete")
+	color := "#9b59b6"
+
+	resource.Test(t, resource.TestCase{
+		PreCheck:                 func() { testAccPreCheck(t) },
+		ProtoV6ProviderFactories: testAccProtoV6ProviderFactories,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccTagResourceConfig(name, color),
+				ConfigStateChecks: []statecheck.StateCheck{
+					statecheck.ExpectKnownValue("uptimekuma_tag.test", tfjsonpath.New("name"), knownvalue.StringExact(name)),
+				},
+			},
+			{
+				Config:             testAccTagResourceConfigEmpty(),
+				ExpectNonEmptyPlan: false,
+			},
+		},
+	})
+}
+
+func testAccTagResourceConfigEmpty() string {
+	return providerConfig()
+}


### PR DESCRIPTION
## Description

This PR implements the Phase 1 of issue #27: Tag resource support for the Terraform provider.

## Changes

- **New resource**: \`uptimekuma_tag\` for managing individual tags
- Tag CRUD operations (Create, Read, Update, Delete)
- Comprehensive acceptance tests
- Auto-generated Terraform documentation
- Example Terraform configuration

## Implementation Details

### Schema
- \`id\` (Computed, Int64): Tag identifier
- \`name\` (Required, String): Tag name
- \`color\` (Required, String): Tag color (hex color code)

### CRUD Operations
- Create: Creates a new tag with name and color
- Read: Fetches tag details by ID
- Update: Modifies tag name and/or color
- Delete: Deletes a tag (cascades to remove all monitor-tag associations)

## Testing

- All unit tests pass
- Acceptance tests include:
  - Basic create/read/update/delete
  - Tag name and color updates
  - Delete verification

## Documentation

- Auto-generated documentation in \`docs/resources/tag.md\`
- Example configuration in \`examples/resources/uptimekuma_tag/\`

## Acceptance Criteria

- [x] \`uptimekuma_tag\` resource fully implemented
- [x] All CRUD operations tested and working
- [x] Provider code formatted and linted
- [x] Documentation generated and complete
- [x] No breaking changes to existing resources

Resolves #27