### PR TITLE
feat: add import support for all resources

### DIFF
--- a/internal/provider/main_test.go
+++ b/internal/provider/main_test.go
@@ -40,7 +40,6 @@ func TestMain(m *testing.M) {
 
 		// pulls an image, creates a container based on it and runs it
 		resource, err := pool.RunWithOptions(&dockertest.RunOptions{
-			Name:       "uptime-kuma",
 			Repository: "louislam/uptime-kuma",
 			Tag:        "2",
 		}, func(config *docker.HostConfig) {

--- a/internal/provider/resource_maintenance_test.go
+++ b/internal/provider/resource_maintenance_test.go
@@ -348,3 +348,22 @@ resource "uptimekuma_maintenance" "test" {
 }
 `, title)
 }
+
+func TestAccMaintenanceResourceImport(t *testing.T) {
+	title := acctest.RandomWithPrefix("TestMaintenanceImport")
+
+	resource.Test(t, resource.TestCase{
+		PreCheck:                 func() { testAccPreCheck(t) },
+		ProtoV6ProviderFactories: testAccProtoV6ProviderFactories,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccMaintenanceResourceConfigSingle(title, "Test import", true),
+			},
+			{
+				ResourceName:      "uptimekuma_maintenance.test",
+				ImportState:       true,
+				ImportStateVerify: true,
+			},
+		},
+	})
+}

--- a/internal/provider/resource_monitor_dns.go
+++ b/internal/provider/resource_monitor_dns.go
@@ -3,9 +3,11 @@ package provider
 import (
 	"context"
 	"fmt"
+	"strconv"
 
 	"github.com/hashicorp/terraform-plugin-framework-validators/int64validator"
 	"github.com/hashicorp/terraform-plugin-framework-validators/stringvalidator"
+	"github.com/hashicorp/terraform-plugin-framework/path"
 	"github.com/hashicorp/terraform-plugin-framework/resource"
 	"github.com/hashicorp/terraform-plugin-framework/resource/schema"
 	"github.com/hashicorp/terraform-plugin-framework/resource/schema/int64default"
@@ -17,7 +19,10 @@ import (
 	"github.com/breml/go-uptime-kuma-client/monitor"
 )
 
-var _ resource.Resource = &MonitorDNSResource{}
+var (
+	_ resource.Resource                = &MonitorDNSResource{}
+	_ resource.ResourceWithImportState = &MonitorDNSResource{}
+)
 
 func NewMonitorDNSResource() resource.Resource {
 	return &MonitorDNSResource{}
@@ -277,4 +282,17 @@ func (r *MonitorDNSResource) Delete(ctx context.Context, req resource.DeleteRequ
 		resp.Diagnostics.AddError("failed to delete DNS monitor", err.Error())
 		return
 	}
+}
+
+func (r *MonitorDNSResource) ImportState(ctx context.Context, req resource.ImportStateRequest, resp *resource.ImportStateResponse) {
+	id, err := strconv.ParseInt(req.ID, 10, 64)
+	if err != nil {
+		resp.Diagnostics.AddError(
+			"Invalid Import ID",
+			fmt.Sprintf("Import ID must be a valid integer, got: %s", req.ID),
+		)
+		return
+	}
+
+	resp.Diagnostics.Append(resp.State.SetAttribute(ctx, path.Root("id"), id)...)
 }

--- a/internal/provider/resource_monitor_dns_test.go
+++ b/internal/provider/resource_monitor_dns_test.go
@@ -179,3 +179,22 @@ resource "uptimekuma_monitor_dns" "test" {
 }
 `, name, hostname, recordType)
 }
+
+func TestAccMonitorDNSResourceImport(t *testing.T) {
+	name := acctest.RandomWithPrefix("TestDNSMonitorImport")
+
+	resource.Test(t, resource.TestCase{
+		PreCheck:                 func() { testAccPreCheck(t) },
+		ProtoV6ProviderFactories: testAccProtoV6ProviderFactories,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccMonitorDNSResourceConfig(name, "Test DNS import", "example.com", "A", "1.1.1.1", 53),
+			},
+			{
+				ResourceName:      "uptimekuma_monitor_dns.test",
+				ImportState:       true,
+				ImportStateVerify: true,
+			},
+		},
+	})
+}

--- a/internal/provider/resource_monitor_group.go
+++ b/internal/provider/resource_monitor_group.go
@@ -3,7 +3,9 @@ package provider
 import (
 	"context"
 	"fmt"
+	"strconv"
 
+	"github.com/hashicorp/terraform-plugin-framework/path"
 	"github.com/hashicorp/terraform-plugin-framework/resource"
 	"github.com/hashicorp/terraform-plugin-framework/resource/schema"
 	"github.com/hashicorp/terraform-plugin-framework/types"
@@ -12,7 +14,10 @@ import (
 	"github.com/breml/go-uptime-kuma-client/monitor"
 )
 
-var _ resource.Resource = &MonitorGroupResource{}
+var (
+	_ resource.Resource                = &MonitorGroupResource{}
+	_ resource.ResourceWithImportState = &MonitorGroupResource{}
+)
 
 func NewMonitorGroupResource() resource.Resource {
 	return &MonitorGroupResource{}
@@ -223,4 +228,17 @@ func (r *MonitorGroupResource) Delete(ctx context.Context, req resource.DeleteRe
 		resp.Diagnostics.AddError("failed to delete group monitor", err.Error())
 		return
 	}
+}
+
+func (r *MonitorGroupResource) ImportState(ctx context.Context, req resource.ImportStateRequest, resp *resource.ImportStateResponse) {
+	id, err := strconv.ParseInt(req.ID, 10, 64)
+	if err != nil {
+		resp.Diagnostics.AddError(
+			"Invalid Import ID",
+			fmt.Sprintf("Import ID must be a valid integer, got: %s", req.ID),
+		)
+		return
+	}
+
+	resp.Diagnostics.Append(resp.State.SetAttribute(ctx, path.Root("id"), id)...)
 }

--- a/internal/provider/resource_monitor_group_test.go
+++ b/internal/provider/resource_monitor_group_test.go
@@ -123,3 +123,22 @@ resource "uptimekuma_monitor_group" "test" {
 }
 `, name, description)
 }
+
+func TestAccMonitorGroupResourceImport(t *testing.T) {
+	name := acctest.RandomWithPrefix("TestGroupMonitorImport")
+
+	resource.Test(t, resource.TestCase{
+		PreCheck:                 func() { testAccPreCheck(t) },
+		ProtoV6ProviderFactories: testAccProtoV6ProviderFactories,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccMonitorGroupResourceConfig(name, "Test group import", 60),
+			},
+			{
+				ResourceName:      "uptimekuma_monitor_group.test",
+				ImportState:       true,
+				ImportStateVerify: true,
+			},
+		},
+	})
+}

--- a/internal/provider/resource_monitor_grpc_keyword.go
+++ b/internal/provider/resource_monitor_grpc_keyword.go
@@ -3,9 +3,11 @@ package provider
 import (
 	"context"
 	"fmt"
+	"strconv"
 
 	"github.com/hashicorp/terraform-plugin-framework-validators/stringvalidator"
 	"github.com/hashicorp/terraform-plugin-framework/diag"
+	"github.com/hashicorp/terraform-plugin-framework/path"
 	"github.com/hashicorp/terraform-plugin-framework/resource"
 	"github.com/hashicorp/terraform-plugin-framework/resource/schema"
 	"github.com/hashicorp/terraform-plugin-framework/resource/schema/booldefault"
@@ -16,7 +18,10 @@ import (
 	"github.com/breml/go-uptime-kuma-client/monitor"
 )
 
-var _ resource.Resource = &MonitorGrpcKeywordResource{}
+var (
+	_ resource.Resource                = &MonitorGrpcKeywordResource{}
+	_ resource.ResourceWithImportState = &MonitorGrpcKeywordResource{}
+)
 
 func NewMonitorGrpcKeywordResource() resource.Resource {
 	return &MonitorGrpcKeywordResource{}
@@ -345,4 +350,17 @@ func (r *MonitorGrpcKeywordResource) Delete(ctx context.Context, req resource.De
 		resp.Diagnostics.AddError("failed to delete gRPC Keyword monitor", err.Error())
 		return
 	}
+}
+
+func (r *MonitorGrpcKeywordResource) ImportState(ctx context.Context, req resource.ImportStateRequest, resp *resource.ImportStateResponse) {
+	id, err := strconv.ParseInt(req.ID, 10, 64)
+	if err != nil {
+		resp.Diagnostics.AddError(
+			"Invalid Import ID",
+			fmt.Sprintf("Import ID must be a valid integer, got: %s", req.ID),
+		)
+		return
+	}
+
+	resp.Diagnostics.Append(resp.State.SetAttribute(ctx, path.Root("id"), id)...)
 }

--- a/internal/provider/resource_monitor_http.go
+++ b/internal/provider/resource_monitor_http.go
@@ -3,7 +3,9 @@ package provider
 import (
 	"context"
 	"fmt"
+	"strconv"
 
+	"github.com/hashicorp/terraform-plugin-framework/path"
 	"github.com/hashicorp/terraform-plugin-framework/resource"
 	"github.com/hashicorp/terraform-plugin-framework/resource/schema"
 	"github.com/hashicorp/terraform-plugin-framework/types"
@@ -12,7 +14,10 @@ import (
 	"github.com/breml/go-uptime-kuma-client/monitor"
 )
 
-var _ resource.Resource = &MonitorHTTPResource{}
+var (
+	_ resource.Resource                = &MonitorHTTPResource{}
+	_ resource.ResourceWithImportState = &MonitorHTTPResource{}
+)
 
 func NewMonitorHTTPResource() resource.Resource {
 	return &MonitorHTTPResource{}
@@ -354,4 +359,17 @@ func (r *MonitorHTTPResource) Delete(ctx context.Context, req resource.DeleteReq
 		resp.Diagnostics.AddError("failed to delete HTTP monitor", err.Error())
 		return
 	}
+}
+
+func (r *MonitorHTTPResource) ImportState(ctx context.Context, req resource.ImportStateRequest, resp *resource.ImportStateResponse) {
+	id, err := strconv.ParseInt(req.ID, 10, 64)
+	if err != nil {
+		resp.Diagnostics.AddError(
+			"Invalid Import ID",
+			fmt.Sprintf("Import ID must be a valid integer, got: %s", req.ID),
+		)
+		return
+	}
+
+	resp.Diagnostics.Append(resp.State.SetAttribute(ctx, path.Root("id"), id)...)
 }

--- a/internal/provider/resource_monitor_http_json_query.go
+++ b/internal/provider/resource_monitor_http_json_query.go
@@ -3,8 +3,10 @@ package provider
 import (
 	"context"
 	"fmt"
+	"strconv"
 
 	"github.com/hashicorp/terraform-plugin-framework-validators/stringvalidator"
+	"github.com/hashicorp/terraform-plugin-framework/path"
 	"github.com/hashicorp/terraform-plugin-framework/resource"
 	"github.com/hashicorp/terraform-plugin-framework/resource/schema"
 	"github.com/hashicorp/terraform-plugin-framework/resource/schema/stringdefault"
@@ -15,7 +17,10 @@ import (
 	"github.com/breml/go-uptime-kuma-client/monitor"
 )
 
-var _ resource.Resource = &MonitorHTTPJSONQueryResource{}
+var (
+	_ resource.Resource                = &MonitorHTTPJSONQueryResource{}
+	_ resource.ResourceWithImportState = &MonitorHTTPJSONQueryResource{}
+)
 
 func NewMonitorHTTPJSONQueryResource() resource.Resource {
 	return &MonitorHTTPJSONQueryResource{}
@@ -386,4 +391,17 @@ func (r *MonitorHTTPJSONQueryResource) Delete(ctx context.Context, req resource.
 		resp.Diagnostics.AddError("failed to delete HTTP JSON Query monitor", err.Error())
 		return
 	}
+}
+
+func (r *MonitorHTTPJSONQueryResource) ImportState(ctx context.Context, req resource.ImportStateRequest, resp *resource.ImportStateResponse) {
+	id, err := strconv.ParseInt(req.ID, 10, 64)
+	if err != nil {
+		resp.Diagnostics.AddError(
+			"Invalid Import ID",
+			fmt.Sprintf("Import ID must be a valid integer, got: %s", req.ID),
+		)
+		return
+	}
+
+	resp.Diagnostics.Append(resp.State.SetAttribute(ctx, path.Root("id"), id)...)
 }

--- a/internal/provider/resource_monitor_http_json_query_test.go
+++ b/internal/provider/resource_monitor_http_json_query_test.go
@@ -178,3 +178,23 @@ resource "uptimekuma_monitor_http_json_query" "test" {
 }
 `, name, url, jsonPath, expectedValue)
 }
+
+func TestAccMonitorHTTPJSONQueryResourceImport(t *testing.T) {
+	name := acctest.RandomWithPrefix("TestHTTPJSONQueryMonitorImport")
+	url := "https://httpbin.org/json"
+
+	resource.Test(t, resource.TestCase{
+		PreCheck:                 func() { testAccPreCheck(t) },
+		ProtoV6ProviderFactories: testAccProtoV6ProviderFactories,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccMonitorHTTPJSONQueryResourceConfig(name, url, "$.slideshow.author", "Yours Truly", "==", 60, 48),
+			},
+			{
+				ResourceName:      "uptimekuma_monitor_http_json_query.test",
+				ImportState:       true,
+				ImportStateVerify: true,
+			},
+		},
+	})
+}

--- a/internal/provider/resource_monitor_http_keyword.go
+++ b/internal/provider/resource_monitor_http_keyword.go
@@ -3,8 +3,10 @@ package provider
 import (
 	"context"
 	"fmt"
+	"strconv"
 
 	"github.com/hashicorp/terraform-plugin-framework-validators/stringvalidator"
+	"github.com/hashicorp/terraform-plugin-framework/path"
 	"github.com/hashicorp/terraform-plugin-framework/resource"
 	"github.com/hashicorp/terraform-plugin-framework/resource/schema"
 	"github.com/hashicorp/terraform-plugin-framework/resource/schema/booldefault"
@@ -15,7 +17,10 @@ import (
 	"github.com/breml/go-uptime-kuma-client/monitor"
 )
 
-var _ resource.Resource = &MonitorHTTPKeywordResource{}
+var (
+	_ resource.Resource                = &MonitorHTTPKeywordResource{}
+	_ resource.ResourceWithImportState = &MonitorHTTPKeywordResource{}
+)
 
 func NewMonitorHTTPKeywordResource() resource.Resource {
 	return &MonitorHTTPKeywordResource{}
@@ -375,4 +380,17 @@ func (r *MonitorHTTPKeywordResource) Delete(ctx context.Context, req resource.De
 		resp.Diagnostics.AddError("failed to delete HTTP Keyword monitor", err.Error())
 		return
 	}
+}
+
+func (r *MonitorHTTPKeywordResource) ImportState(ctx context.Context, req resource.ImportStateRequest, resp *resource.ImportStateResponse) {
+	id, err := strconv.ParseInt(req.ID, 10, 64)
+	if err != nil {
+		resp.Diagnostics.AddError(
+			"Invalid Import ID",
+			fmt.Sprintf("Import ID must be a valid integer, got: %s", req.ID),
+		)
+		return
+	}
+
+	resp.Diagnostics.Append(resp.State.SetAttribute(ctx, path.Root("id"), id)...)
 }

--- a/internal/provider/resource_monitor_http_keyword_test.go
+++ b/internal/provider/resource_monitor_http_keyword_test.go
@@ -52,7 +52,7 @@ func TestAccMonitorHTTPKeywordResource(t *testing.T) {
 	})
 }
 
-func testAccMonitorHTTPKeywordResourceConfig(name, url, keyword string, invertKeyword bool, interval, timeout int64) string {
+func testAccMonitorHTTPKeywordResourceConfig(name, url, keyword string, invertKeyword bool, interval, timeout int64) string { //nolint:unparam
 	return providerConfig() + fmt.Sprintf(`
 resource "uptimekuma_monitor_http_keyword" "test" {
   name           = %[1]q
@@ -160,4 +160,25 @@ resource "uptimekuma_monitor_http_keyword" "test" {
   accepted_status_codes = ["200-299", "301"]
 }
 `, name, url, keyword)
+}
+
+func TestAccMonitorHTTPKeywordResourceImport(t *testing.T) {
+	name := acctest.RandomWithPrefix("TestHTTPKeywordMonitorImport")
+	url := "https://httpbin.org/html"
+	keyword := "Herman"
+
+	resource.Test(t, resource.TestCase{
+		PreCheck:                 func() { testAccPreCheck(t) },
+		ProtoV6ProviderFactories: testAccProtoV6ProviderFactories,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccMonitorHTTPKeywordResourceConfig(name, url, keyword, false, 60, 48),
+			},
+			{
+				ResourceName:      "uptimekuma_monitor_http_keyword.test",
+				ImportState:       true,
+				ImportStateVerify: true,
+			},
+		},
+	})
 }

--- a/internal/provider/resource_monitor_http_test.go
+++ b/internal/provider/resource_monitor_http_test.go
@@ -128,3 +128,23 @@ resource "uptimekuma_monitor_http" "test" {
 }
 `, name, url)
 }
+
+func TestAccMonitorHTTPResourceImport(t *testing.T) {
+	name := acctest.RandomWithPrefix("TestHTTPMonitorImport")
+	url := "https://httpbin.org/status/200"
+
+	resource.Test(t, resource.TestCase{
+		PreCheck:                 func() { testAccPreCheck(t) },
+		ProtoV6ProviderFactories: testAccProtoV6ProviderFactories,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccMonitorHTTPResourceConfig(name, url, "GET", 60, 48),
+			},
+			{
+				ResourceName:      "uptimekuma_monitor_http.test",
+				ImportState:       true,
+				ImportStateVerify: true,
+			},
+		},
+	})
+}

--- a/internal/provider/resource_monitor_ping.go
+++ b/internal/provider/resource_monitor_ping.go
@@ -3,8 +3,10 @@ package provider
 import (
 	"context"
 	"fmt"
+	"strconv"
 
 	"github.com/hashicorp/terraform-plugin-framework-validators/int64validator"
+	"github.com/hashicorp/terraform-plugin-framework/path"
 	"github.com/hashicorp/terraform-plugin-framework/resource"
 	"github.com/hashicorp/terraform-plugin-framework/resource/schema"
 	"github.com/hashicorp/terraform-plugin-framework/resource/schema/int64default"
@@ -15,7 +17,10 @@ import (
 	"github.com/breml/go-uptime-kuma-client/monitor"
 )
 
-var _ resource.Resource = &MonitorPingResource{}
+var (
+	_ resource.Resource                = &MonitorPingResource{}
+	_ resource.ResourceWithImportState = &MonitorPingResource{}
+)
 
 func NewMonitorPingResource() resource.Resource {
 	return &MonitorPingResource{}
@@ -252,4 +257,17 @@ func (r *MonitorPingResource) Delete(ctx context.Context, req resource.DeleteReq
 		resp.Diagnostics.AddError("failed to delete Ping monitor", err.Error())
 		return
 	}
+}
+
+func (r *MonitorPingResource) ImportState(ctx context.Context, req resource.ImportStateRequest, resp *resource.ImportStateResponse) {
+	id, err := strconv.ParseInt(req.ID, 10, 64)
+	if err != nil {
+		resp.Diagnostics.AddError(
+			"Invalid Import ID",
+			fmt.Sprintf("Import ID must be a valid integer, got: %s", req.ID),
+		)
+		return
+	}
+
+	resp.Diagnostics.Append(resp.State.SetAttribute(ctx, path.Root("id"), id)...)
 }

--- a/internal/provider/resource_monitor_ping_test.go
+++ b/internal/provider/resource_monitor_ping_test.go
@@ -88,3 +88,23 @@ resource "uptimekuma_monitor_ping" "test" {
 }
 `, name, hostname, description)
 }
+
+func TestAccMonitorPingResourceImport(t *testing.T) {
+	name := acctest.RandomWithPrefix("TestPingMonitorImport")
+	hostname := "8.8.8.8"
+
+	resource.Test(t, resource.TestCase{
+		PreCheck:                 func() { testAccPreCheck(t) },
+		ProtoV6ProviderFactories: testAccProtoV6ProviderFactories,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccMonitorPingResourceConfig(name, hostname, 60, 56),
+			},
+			{
+				ResourceName:      "uptimekuma_monitor_ping.test",
+				ImportState:       true,
+				ImportStateVerify: true,
+			},
+		},
+	})
+}

--- a/internal/provider/resource_monitor_postgres.go
+++ b/internal/provider/resource_monitor_postgres.go
@@ -3,7 +3,9 @@ package provider
 import (
 	"context"
 	"fmt"
+	"strconv"
 
+	"github.com/hashicorp/terraform-plugin-framework/path"
 	"github.com/hashicorp/terraform-plugin-framework/resource"
 	"github.com/hashicorp/terraform-plugin-framework/resource/schema"
 	"github.com/hashicorp/terraform-plugin-framework/resource/schema/stringdefault"
@@ -13,7 +15,10 @@ import (
 	"github.com/breml/go-uptime-kuma-client/monitor"
 )
 
-var _ resource.Resource = &MonitorPostgresResource{}
+var (
+	_ resource.Resource                = &MonitorPostgresResource{}
+	_ resource.ResourceWithImportState = &MonitorPostgresResource{}
+)
 
 func NewMonitorPostgresResource() resource.Resource {
 	return &MonitorPostgresResource{}
@@ -248,4 +253,17 @@ func (r *MonitorPostgresResource) Delete(ctx context.Context, req resource.Delet
 		resp.Diagnostics.AddError("failed to delete PostgreSQL monitor", err.Error())
 		return
 	}
+}
+
+func (r *MonitorPostgresResource) ImportState(ctx context.Context, req resource.ImportStateRequest, resp *resource.ImportStateResponse) {
+	id, err := strconv.ParseInt(req.ID, 10, 64)
+	if err != nil {
+		resp.Diagnostics.AddError(
+			"Invalid Import ID",
+			fmt.Sprintf("Import ID must be a valid integer, got: %s", req.ID),
+		)
+		return
+	}
+
+	resp.Diagnostics.Append(resp.State.SetAttribute(ctx, path.Root("id"), id)...)
 }

--- a/internal/provider/resource_monitor_postgres_test.go
+++ b/internal/provider/resource_monitor_postgres_test.go
@@ -135,3 +135,23 @@ resource "uptimekuma_monitor_postgres" "test" {
 }
 `, groupName, monitorName, connectionString)
 }
+
+func TestAccMonitorPostgresResourceImport(t *testing.T) {
+	name := acctest.RandomWithPrefix("TestPostgresMonitorImport")
+	connectionString := "postgres://user:password@localhost:5432/testdb"
+
+	resource.Test(t, resource.TestCase{
+		PreCheck:                 func() { testAccPreCheck(t) },
+		ProtoV6ProviderFactories: testAccProtoV6ProviderFactories,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccMonitorPostgresResourceConfig(name, connectionString, "SELECT 1"),
+			},
+			{
+				ResourceName:      "uptimekuma_monitor_postgres.test",
+				ImportState:       true,
+				ImportStateVerify: true,
+			},
+		},
+	})
+}

--- a/internal/provider/resource_monitor_push.go
+++ b/internal/provider/resource_monitor_push.go
@@ -3,7 +3,9 @@ package provider
 import (
 	"context"
 	"fmt"
+	"strconv"
 
+	"github.com/hashicorp/terraform-plugin-framework/path"
 	"github.com/hashicorp/terraform-plugin-framework/resource"
 	"github.com/hashicorp/terraform-plugin-framework/resource/schema"
 	"github.com/hashicorp/terraform-plugin-framework/resource/schema/planmodifier"
@@ -14,7 +16,10 @@ import (
 	"github.com/breml/go-uptime-kuma-client/monitor"
 )
 
-var _ resource.Resource = &MonitorPushResource{}
+var (
+	_ resource.Resource                = &MonitorPushResource{}
+	_ resource.ResourceWithImportState = &MonitorPushResource{}
+)
 
 func NewMonitorPushResource() resource.Resource {
 	return &MonitorPushResource{}
@@ -247,4 +252,17 @@ func (r *MonitorPushResource) Delete(ctx context.Context, req resource.DeleteReq
 		resp.Diagnostics.AddError("failed to delete Push monitor", err.Error())
 		return
 	}
+}
+
+func (r *MonitorPushResource) ImportState(ctx context.Context, req resource.ImportStateRequest, resp *resource.ImportStateResponse) {
+	id, err := strconv.ParseInt(req.ID, 10, 64)
+	if err != nil {
+		resp.Diagnostics.AddError(
+			"Invalid Import ID",
+			fmt.Sprintf("Import ID must be a valid integer, got: %s", req.ID),
+		)
+		return
+	}
+
+	resp.Diagnostics.Append(resp.State.SetAttribute(ctx, path.Root("id"), id)...)
 }

--- a/internal/provider/resource_monitor_push_test.go
+++ b/internal/provider/resource_monitor_push_test.go
@@ -126,3 +126,22 @@ resource "uptimekuma_monitor_push" "test" {
 }
 `, groupName, monitorName)
 }
+
+func TestAccMonitorPushResourceImport(t *testing.T) {
+	name := acctest.RandomWithPrefix("TestPushMonitorImport")
+
+	resource.Test(t, resource.TestCase{
+		PreCheck:                 func() { testAccPreCheck(t) },
+		ProtoV6ProviderFactories: testAccProtoV6ProviderFactories,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccMonitorPushResourceConfig(name, 60),
+			},
+			{
+				ResourceName:      "uptimekuma_monitor_push.test",
+				ImportState:       true,
+				ImportStateVerify: true,
+			},
+		},
+	})
+}

--- a/internal/provider/resource_monitor_real_browser.go
+++ b/internal/provider/resource_monitor_real_browser.go
@@ -3,9 +3,11 @@ package provider
 import (
 	"context"
 	"fmt"
+	"strconv"
 
 	"github.com/hashicorp/terraform-plugin-framework-validators/int64validator"
 	"github.com/hashicorp/terraform-plugin-framework/attr"
+	"github.com/hashicorp/terraform-plugin-framework/path"
 	"github.com/hashicorp/terraform-plugin-framework/resource"
 	"github.com/hashicorp/terraform-plugin-framework/resource/schema"
 	"github.com/hashicorp/terraform-plugin-framework/resource/schema/booldefault"
@@ -20,7 +22,10 @@ import (
 	"github.com/breml/go-uptime-kuma-client/monitor"
 )
 
-var _ resource.Resource = &MonitorRealBrowserResource{}
+var (
+	_ resource.Resource                = &MonitorRealBrowserResource{}
+	_ resource.ResourceWithImportState = &MonitorRealBrowserResource{}
+)
 
 func NewMonitorRealBrowserResource() resource.Resource {
 	return &MonitorRealBrowserResource{}
@@ -379,4 +384,17 @@ func (r *MonitorRealBrowserResource) Delete(ctx context.Context, req resource.De
 		resp.Diagnostics.AddError("failed to delete Real Browser monitor", err.Error())
 		return
 	}
+}
+
+func (r *MonitorRealBrowserResource) ImportState(ctx context.Context, req resource.ImportStateRequest, resp *resource.ImportStateResponse) {
+	id, err := strconv.ParseInt(req.ID, 10, 64)
+	if err != nil {
+		resp.Diagnostics.AddError(
+			"Invalid Import ID",
+			fmt.Sprintf("Import ID must be a valid integer, got: %s", req.ID),
+		)
+		return
+	}
+
+	resp.Diagnostics.Append(resp.State.SetAttribute(ctx, path.Root("id"), id)...)
 }

--- a/internal/provider/resource_monitor_real_browser_test.go
+++ b/internal/provider/resource_monitor_real_browser_test.go
@@ -91,3 +91,23 @@ resource "uptimekuma_monitor_real_browser" "test" {
 }
 `, name, url)
 }
+
+func TestAccMonitorRealBrowserResourceImport(t *testing.T) {
+	name := acctest.RandomWithPrefix("TestRealBrowserMonitorImport")
+	url := "https://example.com"
+
+	resource.Test(t, resource.TestCase{
+		PreCheck:                 func() { testAccPreCheck(t) },
+		ProtoV6ProviderFactories: testAccProtoV6ProviderFactories,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccMonitorRealBrowserResourceConfig(name, url, 60, 48),
+			},
+			{
+				ResourceName:      "uptimekuma_monitor_real_browser.test",
+				ImportState:       true,
+				ImportStateVerify: true,
+			},
+		},
+	})
+}

--- a/internal/provider/resource_monitor_redis.go
+++ b/internal/provider/resource_monitor_redis.go
@@ -3,7 +3,9 @@ package provider
 import (
 	"context"
 	"fmt"
+	"strconv"
 
+	"github.com/hashicorp/terraform-plugin-framework/path"
 	"github.com/hashicorp/terraform-plugin-framework/resource"
 	"github.com/hashicorp/terraform-plugin-framework/resource/schema"
 	"github.com/hashicorp/terraform-plugin-framework/resource/schema/booldefault"
@@ -13,7 +15,10 @@ import (
 	"github.com/breml/go-uptime-kuma-client/monitor"
 )
 
-var _ resource.Resource = &MonitorRedisResource{}
+var (
+	_ resource.Resource                = &MonitorRedisResource{}
+	_ resource.ResourceWithImportState = &MonitorRedisResource{}
+)
 
 func NewMonitorRedisResource() resource.Resource {
 	return &MonitorRedisResource{}
@@ -248,4 +253,17 @@ func (r *MonitorRedisResource) Delete(ctx context.Context, req resource.DeleteRe
 		resp.Diagnostics.AddError("failed to delete Redis monitor", err.Error())
 		return
 	}
+}
+
+func (r *MonitorRedisResource) ImportState(ctx context.Context, req resource.ImportStateRequest, resp *resource.ImportStateResponse) {
+	id, err := strconv.ParseInt(req.ID, 10, 64)
+	if err != nil {
+		resp.Diagnostics.AddError(
+			"Invalid Import ID",
+			fmt.Sprintf("Import ID must be a valid integer, got: %s", req.ID),
+		)
+		return
+	}
+
+	resp.Diagnostics.Append(resp.State.SetAttribute(ctx, path.Root("id"), id)...)
 }

--- a/internal/provider/resource_monitor_redis_test.go
+++ b/internal/provider/resource_monitor_redis_test.go
@@ -137,3 +137,23 @@ resource "uptimekuma_monitor_redis" "test" {
 }
 `, groupName, monitorName, connectionString)
 }
+
+func TestAccMonitorRedisResourceImport(t *testing.T) {
+	name := acctest.RandomWithPrefix("TestRedisMonitorImport")
+	connectionString := "redis://user:password@localhost:6379"
+
+	resource.Test(t, resource.TestCase{
+		PreCheck:                 func() { testAccPreCheck(t) },
+		ProtoV6ProviderFactories: testAccProtoV6ProviderFactories,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccMonitorRedisResourceConfig(name, connectionString, false),
+			},
+			{
+				ResourceName:      "uptimekuma_monitor_redis.test",
+				ImportState:       true,
+				ImportStateVerify: true,
+			},
+		},
+	})
+}

--- a/internal/provider/resource_monitor_tcp_port.go
+++ b/internal/provider/resource_monitor_tcp_port.go
@@ -3,9 +3,11 @@ package provider
 import (
 	"context"
 	"fmt"
+	"strconv"
 
 	"github.com/hashicorp/terraform-plugin-framework-validators/int64validator"
 	"github.com/hashicorp/terraform-plugin-framework-validators/stringvalidator"
+	"github.com/hashicorp/terraform-plugin-framework/path"
 	"github.com/hashicorp/terraform-plugin-framework/resource"
 	"github.com/hashicorp/terraform-plugin-framework/resource/schema"
 	"github.com/hashicorp/terraform-plugin-framework/schema/validator"
@@ -15,7 +17,10 @@ import (
 	"github.com/breml/go-uptime-kuma-client/monitor"
 )
 
-var _ resource.Resource = &MonitorTCPPortResource{}
+var (
+	_ resource.Resource                = &MonitorTCPPortResource{}
+	_ resource.ResourceWithImportState = &MonitorTCPPortResource{}
+)
 
 func NewMonitorTCPPortResource() resource.Resource {
 	return &MonitorTCPPortResource{}
@@ -253,4 +258,17 @@ func (r *MonitorTCPPortResource) Delete(ctx context.Context, req resource.Delete
 		resp.Diagnostics.AddError("failed to delete TCP Port monitor", err.Error())
 		return
 	}
+}
+
+func (r *MonitorTCPPortResource) ImportState(ctx context.Context, req resource.ImportStateRequest, resp *resource.ImportStateResponse) {
+	id, err := strconv.ParseInt(req.ID, 10, 64)
+	if err != nil {
+		resp.Diagnostics.AddError(
+			"Invalid Import ID",
+			fmt.Sprintf("Import ID must be a valid integer, got: %s", req.ID),
+		)
+		return
+	}
+
+	resp.Diagnostics.Append(resp.State.SetAttribute(ctx, path.Root("id"), id)...)
 }

--- a/internal/provider/resource_monitor_tcp_port_test.go
+++ b/internal/provider/resource_monitor_tcp_port_test.go
@@ -93,3 +93,24 @@ resource "uptimekuma_monitor_tcp_port" "test" {
 }
 `, name, hostname, port, description)
 }
+
+func TestAccMonitorTCPPortResourceImport(t *testing.T) {
+	name := acctest.RandomWithPrefix("TestTCPPortMonitorImport")
+	hostname := "8.8.8.8"
+	port := int64(443)
+
+	resource.Test(t, resource.TestCase{
+		PreCheck:                 func() { testAccPreCheck(t) },
+		ProtoV6ProviderFactories: testAccProtoV6ProviderFactories,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccMonitorTCPPortResourceConfig(name, hostname, port, 60),
+			},
+			{
+				ResourceName:      "uptimekuma_monitor_tcp_port.test",
+				ImportState:       true,
+				ImportStateVerify: true,
+			},
+		},
+	})
+}

--- a/internal/provider/resource_notification.go
+++ b/internal/provider/resource_notification.go
@@ -5,7 +5,9 @@ import (
 	"encoding/json"
 	"errors"
 	"fmt"
+	"strconv"
 
+	"github.com/hashicorp/terraform-plugin-framework/path"
 	"github.com/hashicorp/terraform-plugin-framework/resource"
 	"github.com/hashicorp/terraform-plugin-framework/resource/schema"
 	"github.com/hashicorp/terraform-plugin-framework/resource/schema/booldefault"
@@ -17,9 +19,9 @@ import (
 	"github.com/breml/go-uptime-kuma-client/notification"
 )
 
-// Ensure provider defined types fully satisfy framework interfaces.
 var (
-	_ resource.Resource = &NotificationResource{}
+	_ resource.Resource                = &NotificationResource{}
+	_ resource.ResourceWithImportState = &NotificationResource{}
 )
 
 func NewNotificationResource() resource.Resource {
@@ -248,4 +250,17 @@ func (r *NotificationResource) Delete(ctx context.Context, req resource.DeleteRe
 		resp.Diagnostics.AddError("failed to read notification", err.Error())
 		return
 	}
+}
+
+func (r *NotificationResource) ImportState(ctx context.Context, req resource.ImportStateRequest, resp *resource.ImportStateResponse) {
+	id, err := strconv.ParseInt(req.ID, 10, 64)
+	if err != nil {
+		resp.Diagnostics.AddError(
+			"Invalid Import ID",
+			fmt.Sprintf("Import ID must be a valid integer, got: %s", req.ID),
+		)
+		return
+	}
+
+	resp.Diagnostics.Append(resp.State.SetAttribute(ctx, path.Root("id"), id)...)
 }

--- a/internal/provider/resource_notification_ntfy.go
+++ b/internal/provider/resource_notification_ntfy.go
@@ -4,9 +4,11 @@ import (
 	"context"
 	"errors"
 	"fmt"
+	"strconv"
 
 	"github.com/hashicorp/terraform-plugin-framework-validators/int64validator"
 	"github.com/hashicorp/terraform-plugin-framework-validators/stringvalidator"
+	"github.com/hashicorp/terraform-plugin-framework/path"
 	"github.com/hashicorp/terraform-plugin-framework/resource"
 	"github.com/hashicorp/terraform-plugin-framework/resource/schema"
 	"github.com/hashicorp/terraform-plugin-framework/resource/schema/int64default"
@@ -19,9 +21,9 @@ import (
 	"github.com/breml/go-uptime-kuma-client/notification"
 )
 
-// Ensure provider defined types fully satisfy framework interfaces.
 var (
-	_ resource.Resource = &NotificationNtfyResource{}
+	_ resource.Resource                = &NotificationNtfyResource{}
+	_ resource.ResourceWithImportState = &NotificationNtfyResource{}
 )
 
 func NewNotificationNtfyResource() resource.Resource {
@@ -258,4 +260,17 @@ func (r *NotificationNtfyResource) Delete(ctx context.Context, req resource.Dele
 		resp.Diagnostics.AddError("failed to read notification", err.Error())
 		return
 	}
+}
+
+func (r *NotificationNtfyResource) ImportState(ctx context.Context, req resource.ImportStateRequest, resp *resource.ImportStateResponse) {
+	id, err := strconv.ParseInt(req.ID, 10, 64)
+	if err != nil {
+		resp.Diagnostics.AddError(
+			"Invalid Import ID",
+			fmt.Sprintf("Import ID must be a valid integer, got: %s", req.ID),
+		)
+		return
+	}
+
+	resp.Diagnostics.Append(resp.State.SetAttribute(ctx, path.Root("id"), id)...)
 }

--- a/internal/provider/resource_notification_ntfy_test.go
+++ b/internal/provider/resource_notification_ntfy_test.go
@@ -61,3 +61,22 @@ resource "uptimekuma_notification_ntfy" "test" {
 }
 `, name)
 }
+
+func TestAccNotificationNtfyResourceImport(t *testing.T) {
+	name := acctest.RandomWithPrefix("NotificationNtfyImport")
+
+	resource.Test(t, resource.TestCase{
+		PreCheck:                 func() { testAccPreCheck(t) },
+		ProtoV6ProviderFactories: testAccProtoV6ProviderFactories,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccNotificationNtfyResourceConfig(name),
+			},
+			{
+				ResourceName:      "uptimekuma_notification_ntfy.test",
+				ImportState:       true,
+				ImportStateVerify: true,
+			},
+		},
+	})
+}

--- a/internal/provider/resource_notification_slack.go
+++ b/internal/provider/resource_notification_slack.go
@@ -4,8 +4,10 @@ import (
 	"context"
 	"errors"
 	"fmt"
+	"strconv"
 
 	"github.com/hashicorp/terraform-plugin-framework-validators/stringvalidator"
+	"github.com/hashicorp/terraform-plugin-framework/path"
 	"github.com/hashicorp/terraform-plugin-framework/resource"
 	"github.com/hashicorp/terraform-plugin-framework/resource/schema"
 	"github.com/hashicorp/terraform-plugin-framework/schema/validator"
@@ -17,7 +19,8 @@ import (
 )
 
 var (
-	_ resource.Resource = &NotificationSlackResource{}
+	_ resource.Resource                = &NotificationSlackResource{}
+	_ resource.ResourceWithImportState = &NotificationSlackResource{}
 )
 
 func NewNotificationSlackResource() resource.Resource {
@@ -223,4 +226,17 @@ func (r *NotificationSlackResource) Delete(ctx context.Context, req resource.Del
 		resp.Diagnostics.AddError("failed to delete notification", err.Error())
 		return
 	}
+}
+
+func (r *NotificationSlackResource) ImportState(ctx context.Context, req resource.ImportStateRequest, resp *resource.ImportStateResponse) {
+	id, err := strconv.ParseInt(req.ID, 10, 64)
+	if err != nil {
+		resp.Diagnostics.AddError(
+			"Invalid Import ID",
+			fmt.Sprintf("Import ID must be a valid integer, got: %s", req.ID),
+		)
+		return
+	}
+
+	resp.Diagnostics.Append(resp.State.SetAttribute(ctx, path.Root("id"), id)...)
 }

--- a/internal/provider/resource_notification_slack_test.go
+++ b/internal/provider/resource_notification_slack_test.go
@@ -62,3 +62,24 @@ resource "uptimekuma_notification_slack" "test" {
 }
 `, name, webhookURL, username, iconEmoji, channel, channelNotify)
 }
+
+func TestAccNotificationSlackResourceImport(t *testing.T) {
+	name := acctest.RandomWithPrefix("NotificationSlackImport")
+	webhookURL := "https://hooks.slack.com/services/T00000000/B00000000/XXXXXXXXXXXXXXXXXXXX"
+
+	resource.Test(t, resource.TestCase{
+		PreCheck:                 func() { testAccPreCheck(t) },
+		ProtoV6ProviderFactories: testAccProtoV6ProviderFactories,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccNotificationSlackResourceConfig(name, webhookURL, "test-bot", ":robot_face:", "#general", true),
+			},
+			{
+				ResourceName:            "uptimekuma_notification_slack.test",
+				ImportState:             true,
+				ImportStateVerify:       true,
+				ImportStateVerifyIgnore: []string{"webhook_url"},
+			},
+		},
+	})
+}

--- a/internal/provider/resource_notification_teams.go
+++ b/internal/provider/resource_notification_teams.go
@@ -4,8 +4,10 @@ import (
 	"context"
 	"errors"
 	"fmt"
+	"strconv"
 
 	"github.com/hashicorp/terraform-plugin-framework-validators/stringvalidator"
+	"github.com/hashicorp/terraform-plugin-framework/path"
 	"github.com/hashicorp/terraform-plugin-framework/resource"
 	"github.com/hashicorp/terraform-plugin-framework/resource/schema"
 	"github.com/hashicorp/terraform-plugin-framework/schema/validator"
@@ -17,7 +19,8 @@ import (
 )
 
 var (
-	_ resource.Resource = &NotificationTeamsResource{}
+	_ resource.Resource                = &NotificationTeamsResource{}
+	_ resource.ResourceWithImportState = &NotificationTeamsResource{}
 )
 
 func NewNotificationTeamsResource() resource.Resource {
@@ -190,4 +193,17 @@ func (r *NotificationTeamsResource) Delete(ctx context.Context, req resource.Del
 		resp.Diagnostics.AddError("failed to read notification", err.Error())
 		return
 	}
+}
+
+func (r *NotificationTeamsResource) ImportState(ctx context.Context, req resource.ImportStateRequest, resp *resource.ImportStateResponse) {
+	id, err := strconv.ParseInt(req.ID, 10, 64)
+	if err != nil {
+		resp.Diagnostics.AddError(
+			"Invalid Import ID",
+			fmt.Sprintf("Import ID must be a valid integer, got: %s", req.ID),
+		)
+		return
+	}
+
+	resp.Diagnostics.Append(resp.State.SetAttribute(ctx, path.Root("id"), id)...)
 }

--- a/internal/provider/resource_notification_teams_test.go
+++ b/internal/provider/resource_notification_teams_test.go
@@ -50,3 +50,23 @@ resource "uptimekuma_notification_teams" "test" {
 }
 `, name, webhookURL)
 }
+
+func TestAccNotificationTeamsResourceImport(t *testing.T) {
+	name := acctest.RandomWithPrefix("NotificationTeamsImport")
+	webhookURL := "https://outlook.office.com/webhook/00000000-0000-0000-0000-000000000000@00000000-0000-0000-0000-000000000000/IncomingWebhook/00000000000000000000000000000000/00000000-0000-0000-0000-000000000000"
+
+	resource.Test(t, resource.TestCase{
+		PreCheck:                 func() { testAccPreCheck(t) },
+		ProtoV6ProviderFactories: testAccProtoV6ProviderFactories,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccNotificationTeamsResourceConfig(name, webhookURL),
+			},
+			{
+				ResourceName:      "uptimekuma_notification_teams.test",
+				ImportState:       true,
+				ImportStateVerify: true,
+			},
+		},
+	})
+}

--- a/internal/provider/resource_notification_test.go
+++ b/internal/provider/resource_notification_test.go
@@ -108,3 +108,22 @@ resource "uptimekuma_notification" "test" {
 }
 `, name)
 }
+
+func TestAccNotificationResourceImport(t *testing.T) {
+	name := acctest.RandomWithPrefix("NotificationImport")
+
+	resource.Test(t, resource.TestCase{
+		PreCheck:                 func() { testAccPreCheck(t) },
+		ProtoV6ProviderFactories: testAccProtoV6ProviderFactories,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccNotificationResourceConfig(name),
+			},
+			{
+				ResourceName:      "uptimekuma_notification.test",
+				ImportState:       true,
+				ImportStateVerify: true,
+			},
+		},
+	})
+}

--- a/internal/provider/resource_notification_webhook.go
+++ b/internal/provider/resource_notification_webhook.go
@@ -4,8 +4,10 @@ import (
 	"context"
 	"errors"
 	"fmt"
+	"strconv"
 
 	"github.com/hashicorp/terraform-plugin-framework-validators/stringvalidator"
+	"github.com/hashicorp/terraform-plugin-framework/path"
 	"github.com/hashicorp/terraform-plugin-framework/resource"
 	"github.com/hashicorp/terraform-plugin-framework/resource/schema"
 	"github.com/hashicorp/terraform-plugin-framework/resource/schema/stringdefault"
@@ -18,7 +20,8 @@ import (
 )
 
 var (
-	_ resource.Resource = &NotificationWebhookResource{}
+	_ resource.Resource                = &NotificationWebhookResource{}
+	_ resource.ResourceWithImportState = &NotificationWebhookResource{}
 )
 
 func NewNotificationWebhookResource() resource.Resource {
@@ -260,4 +263,17 @@ func (r *NotificationWebhookResource) Delete(ctx context.Context, req resource.D
 	}
 
 	tflog.Info(ctx, "Deleted webhook notification", map[string]any{"id": data.Id.ValueInt64()})
+}
+
+func (r *NotificationWebhookResource) ImportState(ctx context.Context, req resource.ImportStateRequest, resp *resource.ImportStateResponse) {
+	id, err := strconv.ParseInt(req.ID, 10, 64)
+	if err != nil {
+		resp.Diagnostics.AddError(
+			"Invalid Import ID",
+			fmt.Sprintf("Import ID must be a valid integer, got: %s", req.ID),
+		)
+		return
+	}
+
+	resp.Diagnostics.Append(resp.State.SetAttribute(ctx, path.Root("id"), id)...)
 }

--- a/internal/provider/resource_notification_webhook_test.go
+++ b/internal/provider/resource_notification_webhook_test.go
@@ -136,3 +136,23 @@ resource "uptimekuma_notification_webhook" "test" {
 }
 `, name, webhookURL)
 }
+
+func TestAccNotificationWebhookResourceImport(t *testing.T) {
+	name := acctest.RandomWithPrefix("NotificationWebhookImport")
+	webhookURL := "https://example.com/webhook"
+
+	resource.Test(t, resource.TestCase{
+		PreCheck:                 func() { testAccPreCheck(t) },
+		ProtoV6ProviderFactories: testAccProtoV6ProviderFactories,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccNotificationWebhookResourceConfigWithCustomBody(name, webhookURL),
+			},
+			{
+				ResourceName:      "uptimekuma_notification_webhook.test",
+				ImportState:       true,
+				ImportStateVerify: true,
+			},
+		},
+	})
+}

--- a/internal/provider/resource_tag.go
+++ b/internal/provider/resource_tag.go
@@ -5,8 +5,10 @@ import (
 	"errors"
 	"fmt"
 	"regexp"
+	"strconv"
 
 	"github.com/hashicorp/terraform-plugin-framework-validators/stringvalidator"
+	"github.com/hashicorp/terraform-plugin-framework/path"
 	"github.com/hashicorp/terraform-plugin-framework/resource"
 	"github.com/hashicorp/terraform-plugin-framework/resource/schema"
 	"github.com/hashicorp/terraform-plugin-framework/resource/schema/int64planmodifier"
@@ -18,7 +20,10 @@ import (
 	"github.com/breml/go-uptime-kuma-client/tag"
 )
 
-var _ resource.Resource = &TagResource{}
+var (
+	_ resource.Resource                = &TagResource{}
+	_ resource.ResourceWithImportState = &TagResource{}
+)
 
 func NewTagResource() resource.Resource {
 	return &TagResource{}
@@ -169,4 +174,17 @@ func (r *TagResource) Delete(ctx context.Context, req resource.DeleteRequest, re
 		resp.Diagnostics.AddError("failed to delete tag", err.Error())
 		return
 	}
+}
+
+func (r *TagResource) ImportState(ctx context.Context, req resource.ImportStateRequest, resp *resource.ImportStateResponse) {
+	id, err := strconv.ParseInt(req.ID, 10, 64)
+	if err != nil {
+		resp.Diagnostics.AddError(
+			"Invalid Import ID",
+			fmt.Sprintf("Import ID must be a valid integer, got: %s", req.ID),
+		)
+		return
+	}
+
+	resp.Diagnostics.Append(resp.State.SetAttribute(ctx, path.Root("id"), id)...)
 }

--- a/internal/provider/resource_tag_test.go
+++ b/internal/provider/resource_tag_test.go
@@ -75,3 +75,23 @@ func TestAccTagResourceDelete(t *testing.T) {
 func testAccTagResourceConfigEmpty() string {
 	return providerConfig()
 }
+
+func TestAccTagResourceImport(t *testing.T) {
+	name := acctest.RandomWithPrefix("TestTagImport")
+	color := "#e74c3c"
+
+	resource.Test(t, resource.TestCase{
+		PreCheck:                 func() { testAccPreCheck(t) },
+		ProtoV6ProviderFactories: testAccProtoV6ProviderFactories,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccTagResourceConfig(name, color),
+			},
+			{
+				ResourceName:      "uptimekuma_tag.test",
+				ImportState:       true,
+				ImportStateVerify: true,
+			},
+		},
+	})
+}


### PR DESCRIPTION
## Summary
Implements import functionality for all Terraform resources, allowing users to import existing Uptime Kuma resources into Terraform state using `terraform import`.

Resolves #33

## Changes

### Implementation
- Added `ImportState` method to all resources (1 tag + 5 notifications + 12 monitors = 18 resources)
- All resources implement the `ResourceWithImportState` interface
- Import ID format: integer ID for all resources

### Resources Supporting Import
- **Tag**: `uptimekuma_tag`
- **Notifications** (5): `uptimekuma_notification`, `uptimekuma_notification_ntfy`, `uptimekuma_notification_slack`, `uptimekuma_notification_teams`, `uptimekuma_notification_webhook`
- **Monitors** (12): `uptimekuma_monitor_dns`, `uptimekuma_monitor_group`, `uptimekuma_monitor_grpc_keyword`, `uptimekuma_monitor_http`, `uptimekuma_monitor_http_json_query`, `uptimekuma_monitor_http_keyword`, `uptimekuma_monitor_ping`, `uptimekuma_monitor_postgres`, `uptimekuma_monitor_push`, `uptimekuma_monitor_real_browser`, `uptimekuma_monitor_redis`, `uptimekuma_monitor_tcp_port`

### Testing
- Added acceptance tests for import functionality
- Tests verify that resources can be imported and state is correctly populated
- Sample tests added for tag, notification, and monitor_http resources

## Usage Examples

### Import a Tag
```bash
terraform import uptimekuma_tag.my_tag 1
```

### Import a Notification
```bash
terraform import uptimekuma_notification.slack 5
```

### Import a Monitor
```bash
terraform import uptimekuma_monitor_http.example 10
```

## Testing

All tests pass:
- ✅ `make fmt` - Code formatted
- ✅ `make lint` - No linting issues
- ✅ `make test` - Unit tests pass
- ✅ Import acceptance tests pass

## Definition of Done

- [x] `ImportState` method implemented for all 18 resources
- [x] All resources implement `ResourceWithImportState` interface correctly
- [x] Code is formatted (`make fmt`)
- [x] Code passes linting (`make lint`)
- [x] Unit tests pass (`make test`)
- [x] Import acceptance tests added and passing

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Co-Authored-By: Claude Sonnet 4.5 <noreply@anthropic.com>