### PR TITLE
docs: update CHANGELOG for status page incident support

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,4 +8,5 @@ FEATURES:
 - Support for notifications (Webhook, Slack, Teams, ntfy, Generic)
 - Support for proxy configuration (HTTP, HTTPS, SOCKS5 with optional authentication)
 - Support for tags
+- Support for status pages and incidents
 - Terraform registry documentation and examples


### PR DESCRIPTION
## Summary
- Updates CHANGELOG.md to document the status page incident resource feature
- Completes the final item from issue #31's Definition of Done

## Context
The status page incident resource (`uptimekuma_status_page_incident`) was already fully implemented in PR #39 (commit fac7bfb). This PR adds the missing CHANGELOG entry to complete the feature documentation.

## Changes
- Added "Support for status pages and incidents" to the FEATURES section in CHANGELOG.md

## Related Issues
Closes #31

🤖 Generated with [Claude Code](https://claude.com/claude-code)