### PR TITLE
docs: fix accepted_status_codes example to use list syntax

### DIFF
--- a/docs/resources/monitor_http.md
+++ b/docs/resources/monitor_http.md
@@ -36,7 +36,7 @@ resource "uptimekuma_monitor_http" "example" {
   tls_key               = ""
   tls_ca                = ""
   max_redirects         = 10
-  accepted_status_codes = "200-299"
+  accepted_status_codes = ["200-299"]
   http_body_encoding    = "utf8"
   oauth_auth_method     = ""
   oauth_token_url       = ""

--- a/examples/resources/uptimekuma_monitor_http/resource.tf
+++ b/examples/resources/uptimekuma_monitor_http/resource.tf
@@ -21,7 +21,7 @@ resource "uptimekuma_monitor_http" "example" {
   tls_key               = ""
   tls_ca                = ""
   max_redirects         = 10
-  accepted_status_codes = "200-299"
+  accepted_status_codes = ["200-299"]
   http_body_encoding    = "utf8"
   oauth_auth_method     = ""
   oauth_token_url       = ""


### PR DESCRIPTION
Fix the `uptimekuma_monitor_http` resource example to use the correct list syntax for `accepted_status_codes`.

The attribute is a `List of String`, so it should be:
```hcl
accepted_status_codes = ["200-299"]
```

Instead of the incorrect:
```hcl
accepted_status_codes = "200-299"
```

Closes #204