### PR TITLE
fix: status_page prevent perpetual diff on public_group_list group IDs

### DIFF
--- a/internal/provider/resource_status_page.go
+++ b/internal/provider/resource_status_page.go
@@ -158,6 +158,9 @@ func (*StatusPageResource) Schema(_ context.Context, _ resource.SchemaRequest, r
 							MarkdownDescription: "Public group ID",
 							Computed:            true,
 							Optional:            true,
+							PlanModifiers: []planmodifier.Int64{
+								int64planmodifier.UseStateForUnknown(),
+							},
 						},
 						"name": schema.StringAttribute{
 							MarkdownDescription: "Group display name",

--- a/internal/provider/resource_status_page_groupid_test.go
+++ b/internal/provider/resource_status_page_groupid_test.go
@@ -5,6 +5,9 @@ import (
 
 	"github.com/hashicorp/terraform-plugin-testing/helper/acctest"
 	"github.com/hashicorp/terraform-plugin-testing/helper/resource"
+	"github.com/hashicorp/terraform-plugin-testing/knownvalue"
+	"github.com/hashicorp/terraform-plugin-testing/statecheck"
+	"github.com/hashicorp/terraform-plugin-testing/tfjsonpath"
 )
 
 func TestAccStatusPageGroupIDs(t *testing.T) {
@@ -17,7 +20,24 @@ func TestAccStatusPageGroupIDs(t *testing.T) {
 		ProtoV6ProviderFactories: testAccProtoV6ProviderFactories,
 		Steps: []resource.TestStep{
 			{
-				Config: testAccStatusPageResourceConfigWithMonitors(slug, title, monitorName),
+				Config:             testAccStatusPageResourceConfigWithMonitors(slug, title, monitorName),
+				ExpectNonEmptyPlan: false,
+				ConfigStateChecks: []statecheck.StateCheck{
+					// Verify that the server-assigned group ID is populated in state.
+					statecheck.ExpectKnownValue(
+						"uptimekuma_status_page.test",
+						tfjsonpath.New("public_group_list").AtSliceIndex(0).AtMapKey("id"),
+						knownvalue.NotNull(),
+					),
+				},
+			},
+			{
+				// Identical config, no changes. Reproduces issue #223: without the
+				// UseStateForUnknown plan modifier on public_group_list[].id, Terraform
+				// marks the group ID as (known after apply) on every plan, producing a
+				// perpetual diff.
+				Config:             testAccStatusPageResourceConfigWithMonitors(slug, title, monitorName),
+				ExpectNonEmptyPlan: false,
 			},
 		},
 	})


### PR DESCRIPTION
The nested `id` attribute inside `public_group_list` was declared as Computed and Optional but lacked a UseStateForUnknown plan modifier. Terraform therefore marked each group ID as "(known after apply)" on every plan, even though the value was stable in state after the initial create. Adding the modifier tells the framework to carry the prior state value forward into the plan, eliminating the perpetual drift.

Closes: #223