### PR TITLE
fix: inject server group IDs for null plan values in mergeGroupIDsIntoPlan

### DIFF
--- a/internal/provider/status_page_helpers.go
+++ b/internal/provider/status_page_helpers.go
@@ -29,7 +29,7 @@ func mergeGroupIDsIntoPlan(
 	}
 
 	for i := range planModels {
-		if planModels[i].ID.IsUnknown() {
+		if planModels[i].ID.IsUnknown() || planModels[i].ID.IsNull() {
 			if i < len(savedGroups) {
 				planModels[i].ID = types.Int64Value(savedGroups[i].ID)
 			} else {


### PR DESCRIPTION
Follow-up to #239 addressing [review feedback](https://github.com/breml/terraform-provider-uptimekuma/pull/239#discussion_r2090694451).

`mergeGroupIDsIntoPlan()` only injected server IDs when the planned ID was unknown. If the plan had a null ID (e.g. user omits the `id` field entirely), the server-assigned ID was never populated. This treats null the same as unknown when merging IDs, while still preserving any user-set explicit IDs.