### PR TITLE
fix: enhance `icon` field in `uptimekuma_status_page`

### DIFF
--- a/docs/resources/status_page.md
+++ b/docs/resources/status_page.md
@@ -57,7 +57,7 @@ resource "uptimekuma_status_page" "example" {
 - `domain_name_list` (List of String) Custom domain names
 - `footer_text` (String) Footer content
 - `google_analytics_id` (String) Google Analytics tracking ID
-- `icon` (String) Base64-encoded icon image
+- `icon` (String) Icon for the status page. Accepts a PNG data URI (`data:image/png;base64,...`) or a URL/path (max 255 characters). When a data URI is provided, Uptime Kuma converts it to a file on disk.
 - `public_group_list` (Attributes List) Monitor grouping configuration (see [below for nested schema](#nestedatt--public_group_list))
 - `published` (Boolean) Whether page is publicly visible
 - `show_certificate_expiry` (Boolean) Show certificate expiry dates

--- a/internal/provider/resource_status_page_test.go
+++ b/internal/provider/resource_status_page_test.go
@@ -219,6 +219,92 @@ resource "uptimekuma_status_page" "test" {
 `, slug, title, description)
 }
 
+func TestAccStatusPageResourceWithIcon(t *testing.T) {
+	slug := acctest.RandomWithPrefix("test-icon")
+	title := "Status Page with Icon"
+	titleUpdated := "Updated Status Page with Icon"
+
+	// 1x1 pixel transparent PNG as data URI.
+	icon := "data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAYAAAAfFcSJAAAAC0lEQVQIHWNgAAIABAABAN4TIQAAAABJRU5ErkJggg=="
+
+	resource.Test(t, resource.TestCase{
+		PreCheck:                 func() { testAccPreCheck(t) },
+		ProtoV6ProviderFactories: testAccProtoV6ProviderFactories,
+		Steps: []resource.TestStep{
+			{
+				Config:             testAccStatusPageResourceConfigWithIcon(slug, title, icon),
+				ExpectNonEmptyPlan: false,
+				ConfigStateChecks: []statecheck.StateCheck{
+					statecheck.ExpectKnownValue(
+						"uptimekuma_status_page.test",
+						tfjsonpath.New("slug"),
+						knownvalue.StringExact(slug),
+					),
+					statecheck.ExpectKnownValue(
+						"uptimekuma_status_page.test",
+						tfjsonpath.New("title"),
+						knownvalue.StringExact(title),
+					),
+					statecheck.ExpectKnownValue(
+						"uptimekuma_status_page.test",
+						tfjsonpath.New("icon"),
+						knownvalue.StringExact(icon),
+					),
+				},
+			},
+			{
+				Config:             testAccStatusPageResourceConfigWithIcon(slug, titleUpdated, icon),
+				ExpectNonEmptyPlan: false,
+				ConfigStateChecks: []statecheck.StateCheck{
+					statecheck.ExpectKnownValue(
+						"uptimekuma_status_page.test",
+						tfjsonpath.New("title"),
+						knownvalue.StringExact(titleUpdated),
+					),
+					statecheck.ExpectKnownValue(
+						"uptimekuma_status_page.test",
+						tfjsonpath.New("icon"),
+						knownvalue.StringExact(icon),
+					),
+				},
+			},
+		},
+	})
+}
+
+func testAccStatusPageResourceConfigWithIcon(slug string, title string, icon string) string {
+	return providerConfig() + fmt.Sprintf(`
+resource "uptimekuma_status_page" "test" {
+  slug  = %[1]q
+  title = %[2]q
+  icon  = %[3]q
+}
+`, slug, title, icon)
+}
+
+func TestAccStatusPageResourceWithIconPath(t *testing.T) {
+	slug := acctest.RandomWithPrefix("test-icon-path")
+	title := "Status Page with Icon Path"
+
+	resource.Test(t, resource.TestCase{
+		PreCheck:                 func() { testAccPreCheck(t) },
+		ProtoV6ProviderFactories: testAccProtoV6ProviderFactories,
+		Steps: []resource.TestStep{
+			{
+				Config:             testAccStatusPageResourceConfigWithIcon(slug, title, "/icon.svg"),
+				ExpectNonEmptyPlan: false,
+				ConfigStateChecks: []statecheck.StateCheck{
+					statecheck.ExpectKnownValue(
+						"uptimekuma_status_page.test",
+						tfjsonpath.New("icon"),
+						knownvalue.StringExact("/icon.svg"),
+					),
+				},
+			},
+		},
+	})
+}
+
 func TestAccStatusPageResourceWithMonitors(t *testing.T) {
 	slug := acctest.RandomWithPrefix("test-monitors")
 	title := "Status Page with Monitors"


### PR DESCRIPTION
Add validation and fix state handling for the status page `icon` field.

**Changes:**

- Add `statusPageIconValidator` to validate the icon format at plan time, rejecting non-PNG data URIs and URL/paths exceeding 255 characters (the Uptime Kuma database column limit).
- Fix `StatusPageResource.Read` to preserve the original data URI in state when the user provides one, since Uptime Kuma converts data URIs to file paths server-side. Without this, a perpetual diff would occur on every plan.
- Update `MarkdownDescription` to clarify the accepted formats: PNG data URI (`data:image/png;base64,...`) or a URL/path (max 255 characters).
- Regenerate documentation.

Closes #241