### PR TITLE
fix: preserve explicit empty strings for status page optional fields

### DIFF
--- a/internal/provider/resource_monitor_http.go
+++ b/internal/provider/resource_monitor_http.go
@@ -194,6 +194,19 @@ func stringOrNull(s string) types.String {
 	return types.StringValue(s)
 }
 
+// stringOrNullPreserveEmpty returns a Terraform String that preserves an
+// explicit empty string set in the configuration. When the API returns an
+// empty string and the current state already holds a non-null value (the
+// user wrote e.g. `description = ""`), the empty string is kept. When the
+// state is null (the user omitted the attribute), null is preserved.
+func stringOrNullPreserveEmpty(apiValue string, stateValue types.String) types.String {
+	if apiValue == "" && stateValue.IsNull() {
+		return types.StringNull()
+	}
+
+	return types.StringValue(apiValue)
+}
+
 // populateHTTPMonitorBaseFieldsForHTTP populates the base HTTP monitor fields from the API response.
 // Extracts HTTP-specific fields from the API response into the model.
 // Handles base monitor fields and all HTTP configuration options.

--- a/internal/provider/resource_status_page.go
+++ b/internal/provider/resource_status_page.go
@@ -374,13 +374,13 @@ func (r *StatusPageResource) Read(ctx context.Context, req resource.ReadRequest,
 
 	data.ID = types.Int64Value(sp.ID)
 	data.Title = types.StringValue(sp.Title)
-	data.Description = stringOrNull(sp.Description)
+	data.Description = stringOrNullPreserveEmpty(sp.Description, data.Description)
 
 	if !data.Icon.IsNull() && !strings.HasPrefix(data.Icon.ValueString(), "data:") {
-		data.Icon = stringOrNull(sp.Icon)
+		data.Icon = stringOrNullPreserveEmpty(sp.Icon, data.Icon)
 	}
 
-	data.Theme = stringOrNull(sp.Theme)
+	data.Theme = stringOrNullPreserveEmpty(sp.Theme, data.Theme)
 
 	// Note: The Uptime Kuma API's saveStatusPage endpoint does not actually update
 	// the published, show_tags, show_powered_by, and show_certificate_expiry fields
@@ -388,9 +388,9 @@ func (r *StatusPageResource) Read(ctx context.Context, req resource.ReadRequest,
 	// Therefore, we don't update these fields from the API response to avoid drift.
 	// We keep whatever values are in the Terraform config/state.
 
-	data.GoogleAnalyticsID = stringOrNull(sp.GoogleAnalyticsID)
-	data.CustomCSS = stringOrNull(sp.CustomCSS)
-	data.FooterText = stringOrNull(sp.FooterText)
+	data.GoogleAnalyticsID = stringOrNullPreserveEmpty(sp.GoogleAnalyticsID, data.GoogleAnalyticsID)
+	data.CustomCSS = stringOrNullPreserveEmpty(sp.CustomCSS, data.CustomCSS)
+	data.FooterText = stringOrNullPreserveEmpty(sp.FooterText, data.FooterText)
 
 	if len(sp.DomainNameList) > 0 {
 		domainNames, diags := types.ListValueFrom(ctx, types.StringType, sp.DomainNameList)


### PR DESCRIPTION
Add `stringOrNullPreserveEmpty` helper that distinguishes between a user explicitly setting a field to `""` and omitting it entirely. Previously, `stringOrNull` in the `Read()` method converted every empty API response to `types.StringNull()`, which caused a perpetual diff when the user had written e.g. `description = ""`.

The fix applies to all optional string fields in `StatusPageResource.Read()`: `description`, `icon`, `theme`, `google_analytics_id`, `custom_css`, and `footer_text`.

Closes #223