### PR TITLE
fix: handle externally deleted resources in Read() functions

### DIFF
--- a/internal/provider/resource_disappears_test.go
+++ b/internal/provider/resource_disappears_test.go
@@ -1,0 +1,288 @@
+package provider
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"os"
+	"strconv"
+	"testing"
+	"time"
+
+	"github.com/hashicorp/terraform-plugin-testing/helper/acctest"
+	"github.com/hashicorp/terraform-plugin-testing/helper/resource"
+	"github.com/hashicorp/terraform-plugin-testing/plancheck"
+	"github.com/hashicorp/terraform-plugin-testing/terraform"
+
+	kuma "github.com/breml/go-uptime-kuma-client"
+)
+
+// testAccNewKumaClient creates a new kuma client for use in acceptance tests.
+// This is used to perform out-of-band operations (e.g. deleting resources)
+// to simulate external modifications.
+func testAccNewKumaClient(t *testing.T) *kuma.Client {
+	t.Helper()
+
+	if os.Getenv(resource.EnvTfAcc) == "" {
+		t.Skip("TF_ACC=1 not set")
+	}
+
+	kumaClient, err := kuma.New(t.Context(), endpoint, username, password)
+	if err != nil {
+		t.Fatalf("failed to create kuma client: %v", err)
+	}
+
+	t.Cleanup(func() {
+		_ = kumaClient.Disconnect()
+	})
+
+	return kumaClient
+}
+
+// testAccDeleteMonitorExternally deletes a monitor via the kuma API, simulating
+// an external deletion outside of Terraform.
+func testAccDeleteMonitorExternally(
+	t *testing.T,
+	kumaClient *kuma.Client,
+	resourceAddr string,
+) resource.TestCheckFunc {
+	t.Helper()
+
+	return func(s *terraform.State) error {
+		rs, ok := s.RootModule().Resources[resourceAddr]
+		if !ok {
+			return fmt.Errorf("resource %s not found in state", resourceAddr)
+		}
+
+		id, err := strconv.ParseInt(rs.Primary.Attributes["id"], 10, 64)
+		if err != nil {
+			return fmt.Errorf("failed to parse monitor id: %w", err)
+		}
+
+		ctx, cancel := context.WithTimeout(t.Context(), 10*time.Second)
+		defer cancel()
+
+		deleteErr := kumaClient.DeleteMonitor(ctx, id)
+		if deleteErr != nil {
+			return fmt.Errorf("failed to delete monitor externally: %w", deleteErr)
+		}
+
+		return nil
+	}
+}
+
+// TestAccMonitorHTTPResource_disappears verifies that when an HTTP monitor is
+// deleted externally (outside Terraform), the provider removes it from state
+// and plans to recreate it.
+func TestAccMonitorHTTPResource_disappears(t *testing.T) {
+	name := acctest.RandomWithPrefix("TestHTTPDisappears")
+	url := "https://httpbin.org/status/200"
+	kumaClient := testAccNewKumaClient(t)
+
+	resource.Test(t, resource.TestCase{
+		PreCheck:                 func() { testAccPreCheck(t) },
+		ProtoV6ProviderFactories: testAccProtoV6ProviderFactories,
+		Steps: []resource.TestStep{
+			{
+				Config:             testAccMonitorHTTPResourceConfig(name, url, "GET", 60, 48),
+				Check:              testAccDeleteMonitorExternally(t, kumaClient, "uptimekuma_monitor_http.test"),
+				ExpectNonEmptyPlan: true,
+			},
+			{
+				RefreshState:       true,
+				ExpectNonEmptyPlan: true,
+				RefreshPlanChecks: resource.RefreshPlanChecks{
+					PostRefresh: []plancheck.PlanCheck{
+						plancheck.ExpectResourceAction(
+							"uptimekuma_monitor_http.test",
+							plancheck.ResourceActionCreate,
+						),
+					},
+				},
+			},
+		},
+	})
+}
+
+// TestAccMonitorPingResource_disappears verifies that when a Ping monitor is
+// deleted externally, the provider removes it from state and plans to recreate it.
+func TestAccMonitorPingResource_disappears(t *testing.T) {
+	name := acctest.RandomWithPrefix("TestPingDisappears")
+	kumaClient := testAccNewKumaClient(t)
+
+	config := providerConfig() + fmt.Sprintf(`
+resource "uptimekuma_monitor_ping" "test" {
+  name     = %[1]q
+  hostname = "8.8.8.8"
+}
+`, name)
+
+	resource.Test(t, resource.TestCase{
+		PreCheck:                 func() { testAccPreCheck(t) },
+		ProtoV6ProviderFactories: testAccProtoV6ProviderFactories,
+		Steps: []resource.TestStep{
+			{
+				Config:             config,
+				Check:              testAccDeleteMonitorExternally(t, kumaClient, "uptimekuma_monitor_ping.test"),
+				ExpectNonEmptyPlan: true,
+			},
+			{
+				RefreshState:       true,
+				ExpectNonEmptyPlan: true,
+				RefreshPlanChecks: resource.RefreshPlanChecks{
+					PostRefresh: []plancheck.PlanCheck{
+						plancheck.ExpectResourceAction(
+							"uptimekuma_monitor_ping.test",
+							plancheck.ResourceActionCreate,
+						),
+					},
+				},
+			},
+		},
+	})
+}
+
+// TestAccMonitorGroupResource_disappears verifies that when a monitor group is
+// deleted externally, the provider removes it from state and plans to recreate it.
+func TestAccMonitorGroupResource_disappears(t *testing.T) {
+	name := acctest.RandomWithPrefix("TestGroupDisappears")
+	kumaClient := testAccNewKumaClient(t)
+
+	config := providerConfig() + fmt.Sprintf(`
+resource "uptimekuma_monitor_group" "test" {
+  name = %[1]q
+}
+`, name)
+
+	resource.Test(t, resource.TestCase{
+		PreCheck:                 func() { testAccPreCheck(t) },
+		ProtoV6ProviderFactories: testAccProtoV6ProviderFactories,
+		Steps: []resource.TestStep{
+			{
+				Config:             config,
+				Check:              testAccDeleteMonitorExternally(t, kumaClient, "uptimekuma_monitor_group.test"),
+				ExpectNonEmptyPlan: true,
+			},
+			{
+				RefreshState:       true,
+				ExpectNonEmptyPlan: true,
+				RefreshPlanChecks: resource.RefreshPlanChecks{
+					PostRefresh: []plancheck.PlanCheck{
+						plancheck.ExpectResourceAction(
+							"uptimekuma_monitor_group.test",
+							plancheck.ResourceActionCreate,
+						),
+					},
+				},
+			},
+		},
+	})
+}
+
+// TestAccTagResource_disappears verifies that when a tag is deleted externally,
+// the provider removes it from state and plans to recreate it.
+func TestAccTagResource_disappears(t *testing.T) {
+	name := acctest.RandomWithPrefix("TestTagDisappears")
+	color := "#3498db"
+	kumaClient := testAccNewKumaClient(t)
+
+	resource.Test(t, resource.TestCase{
+		PreCheck:                 func() { testAccPreCheck(t) },
+		ProtoV6ProviderFactories: testAccProtoV6ProviderFactories,
+		Steps: []resource.TestStep{
+			{
+				Config:             testAccTagResourceConfig(name, color),
+				ExpectNonEmptyPlan: true,
+				Check: func(s *terraform.State) error {
+					rs, ok := s.RootModule().Resources["uptimekuma_tag.test"]
+					if !ok {
+						return errors.New("resource uptimekuma_tag.test not found in state")
+					}
+
+					id, err := strconv.ParseInt(rs.Primary.Attributes["id"], 10, 64)
+					if err != nil {
+						return fmt.Errorf("failed to parse tag id: %w", err)
+					}
+
+					ctx, cancel := context.WithTimeout(t.Context(), 10*time.Second)
+					defer cancel()
+
+					deleteErr := kumaClient.DeleteTag(ctx, id)
+					if deleteErr != nil {
+						return fmt.Errorf("failed to delete tag externally: %w", deleteErr)
+					}
+
+					return nil
+				},
+			},
+			{
+				RefreshState:       true,
+				ExpectNonEmptyPlan: true,
+				RefreshPlanChecks: resource.RefreshPlanChecks{
+					PostRefresh: []plancheck.PlanCheck{
+						plancheck.ExpectResourceAction(
+							"uptimekuma_tag.test",
+							plancheck.ResourceActionCreate,
+						),
+					},
+				},
+			},
+		},
+	})
+}
+
+// TestAccStatusPageResource_disappears verifies that when a status page is
+// deleted externally, the provider removes it from state and plans to recreate it.
+func TestAccStatusPageResource_disappears(t *testing.T) {
+	slug := acctest.RandomWithPrefix("test-disappears")
+	title := "Disappears Test Status Page"
+	kumaClient := testAccNewKumaClient(t)
+
+	config := providerConfig() + fmt.Sprintf(`
+resource "uptimekuma_status_page" "test" {
+  slug  = %[1]q
+  title = %[2]q
+}
+`, slug, title)
+
+	resource.Test(t, resource.TestCase{
+		PreCheck:                 func() { testAccPreCheck(t) },
+		ProtoV6ProviderFactories: testAccProtoV6ProviderFactories,
+		Steps: []resource.TestStep{
+			{
+				Config:             config,
+				ExpectNonEmptyPlan: true,
+				Check: func(s *terraform.State) error {
+					rs, ok := s.RootModule().Resources["uptimekuma_status_page.test"]
+					if !ok {
+						return errors.New("resource uptimekuma_status_page.test not found in state")
+					}
+
+					slugVal := rs.Primary.Attributes["slug"]
+
+					ctx, cancel := context.WithTimeout(t.Context(), 10*time.Second)
+					defer cancel()
+
+					err := kumaClient.DeleteStatusPage(ctx, slugVal)
+					if err != nil {
+						return fmt.Errorf("failed to delete status page externally: %w", err)
+					}
+
+					return nil
+				},
+			},
+			{
+				RefreshState:       true,
+				ExpectNonEmptyPlan: true,
+				RefreshPlanChecks: resource.RefreshPlanChecks{
+					PostRefresh: []plancheck.PlanCheck{
+						plancheck.ExpectResourceAction(
+							"uptimekuma_status_page.test",
+							plancheck.ResourceActionCreate,
+						),
+					},
+				},
+			},
+		},
+	})
+}

--- a/internal/provider/resource_monitor_dns.go
+++ b/internal/provider/resource_monitor_dns.go
@@ -2,7 +2,6 @@ package provider
 
 import (
 	"context"
-	"errors"
 	"fmt"
 	"strconv"
 
@@ -199,7 +198,7 @@ func (r *MonitorDNSResource) Read(ctx context.Context, req resource.ReadRequest,
 	err := r.client.GetMonitorAs(ctx, data.ID.ValueInt64(), &dnsMonitor)
 	// Handle error.
 	if err != nil {
-		if errors.Is(err, kuma.ErrNotFound) {
+		if isNotFoundError(err) {
 			resp.State.RemoveResource(ctx)
 			return
 		}

--- a/internal/provider/resource_monitor_docker.go
+++ b/internal/provider/resource_monitor_docker.go
@@ -2,7 +2,6 @@ package provider
 
 import (
 	"context"
-	"errors"
 	"fmt"
 	"strconv"
 
@@ -208,7 +207,7 @@ func (r *MonitorDockerResource) Read(ctx context.Context, req resource.ReadReque
 	var dockerMonitor monitor.Docker
 	err := r.client.GetMonitorAs(ctx, data.ID.ValueInt64(), &dockerMonitor)
 	if err != nil {
-		if errors.Is(err, kuma.ErrNotFound) {
+		if isNotFoundError(err) {
 			resp.State.RemoveResource(ctx)
 			return
 		}

--- a/internal/provider/resource_monitor_group.go
+++ b/internal/provider/resource_monitor_group.go
@@ -2,7 +2,6 @@ package provider
 
 import (
 	"context"
-	"errors"
 	"fmt"
 	"strconv"
 
@@ -154,7 +153,7 @@ func (r *MonitorGroupResource) Read(ctx context.Context, req resource.ReadReques
 	err := r.client.GetMonitorAs(ctx, data.ID.ValueInt64(), &groupMonitor)
 	// Handle error.
 	if err != nil {
-		if errors.Is(err, kuma.ErrNotFound) {
+		if isNotFoundError(err) {
 			resp.State.RemoveResource(ctx)
 			return
 		}

--- a/internal/provider/resource_monitor_grpc_keyword.go
+++ b/internal/provider/resource_monitor_grpc_keyword.go
@@ -2,7 +2,6 @@ package provider
 
 import (
 	"context"
-	"errors"
 	"fmt"
 	"strconv"
 
@@ -256,7 +255,7 @@ func (r *MonitorGrpcKeywordResource) Read(ctx context.Context, req resource.Read
 	err := r.client.GetMonitorAs(ctx, data.ID.ValueInt64(), &grpcKeywordMonitor)
 	// Handle error.
 	if err != nil {
-		if errors.Is(err, kuma.ErrNotFound) {
+		if isNotFoundError(err) {
 			resp.State.RemoveResource(ctx)
 			return
 		}

--- a/internal/provider/resource_monitor_helpers.go
+++ b/internal/provider/resource_monitor_helpers.go
@@ -1,6 +1,35 @@
 package provider
 
-import "github.com/hashicorp/terraform-plugin-framework/types"
+import (
+	"errors"
+	"strings"
+
+	kuma "github.com/breml/go-uptime-kuma-client"
+
+	"github.com/hashicorp/terraform-plugin-framework/types"
+)
+
+// isNotFoundError checks whether an error from the kuma client indicates
+// that the requested resource was not found.
+//
+// Resources that are looked up via a cached list (tags, notifications,
+// proxies, docker hosts) return kuma.ErrNotFound.
+//
+// Resources fetched directly from the server (monitors, status pages,
+// maintenance) may return a server-side error from the Uptime Kuma
+// backend when the resource no longer exists.  Known patterns:
+//   - Monitors: "Cannot read properties of null (reading 'id')"
+//   - Status pages: "No slug?"
+func isNotFoundError(err error) bool {
+	if errors.Is(err, kuma.ErrNotFound) {
+		return true
+	}
+
+	msg := err.Error()
+
+	return strings.Contains(msg, "Cannot read properties of null") ||
+		strings.Contains(msg, "No slug?")
+}
 
 // strToPtr converts a Terraform string type to a pointer to string.
 // Returns nil if the value is null or unknown.

--- a/internal/provider/resource_monitor_http.go
+++ b/internal/provider/resource_monitor_http.go
@@ -2,7 +2,6 @@ package provider
 
 import (
 	"context"
-	"errors"
 	"fmt"
 	"strconv"
 
@@ -302,7 +301,7 @@ func (r *MonitorHTTPResource) Read(ctx context.Context, req resource.ReadRequest
 	var httpMonitor monitor.HTTP
 	err := r.client.GetMonitorAs(ctx, data.ID.ValueInt64(), &httpMonitor)
 	if err != nil {
-		if errors.Is(err, kuma.ErrNotFound) {
+		if isNotFoundError(err) {
 			resp.State.RemoveResource(ctx)
 			return
 		}

--- a/internal/provider/resource_monitor_http_json_query.go
+++ b/internal/provider/resource_monitor_http_json_query.go
@@ -2,7 +2,6 @@ package provider
 
 import (
 	"context"
-	"errors"
 	"fmt"
 	"strconv"
 
@@ -341,7 +340,7 @@ func (r *MonitorHTTPJSONQueryResource) Read(
 	var httpJSONQueryMonitor monitor.HTTPJSONQuery
 	err := r.client.GetMonitorAs(ctx, data.ID.ValueInt64(), &httpJSONQueryMonitor)
 	if err != nil {
-		if errors.Is(err, kuma.ErrNotFound) {
+		if isNotFoundError(err) {
 			resp.State.RemoveResource(ctx)
 			return
 		}

--- a/internal/provider/resource_monitor_http_keyword.go
+++ b/internal/provider/resource_monitor_http_keyword.go
@@ -2,7 +2,6 @@ package provider
 
 import (
 	"context"
-	"errors"
 	"fmt"
 	"strconv"
 
@@ -327,7 +326,7 @@ func (r *MonitorHTTPKeywordResource) Read(ctx context.Context, req resource.Read
 	var httpKeywordMonitor monitor.HTTPKeyword
 	err := r.client.GetMonitorAs(ctx, data.ID.ValueInt64(), &httpKeywordMonitor)
 	if err != nil {
-		if errors.Is(err, kuma.ErrNotFound) {
+		if isNotFoundError(err) {
 			resp.State.RemoveResource(ctx)
 			return
 		}

--- a/internal/provider/resource_monitor_mongodb.go
+++ b/internal/provider/resource_monitor_mongodb.go
@@ -2,7 +2,6 @@ package provider
 
 import (
 	"context"
-	"errors"
 	"fmt"
 	"strconv"
 
@@ -197,7 +196,7 @@ func (r *MonitorMongoDBResource) Read(
 	var mongoDBMonitor monitor.MongoDB
 	err := r.client.GetMonitorAs(ctx, data.ID.ValueInt64(), &mongoDBMonitor)
 	if err != nil {
-		if errors.Is(err, kuma.ErrNotFound) {
+		if isNotFoundError(err) {
 			resp.State.RemoveResource(ctx)
 			return
 		}

--- a/internal/provider/resource_monitor_mqtt.go
+++ b/internal/provider/resource_monitor_mqtt.go
@@ -2,7 +2,6 @@ package provider
 
 import (
 	"context"
-	"errors"
 	"fmt"
 	"strconv"
 
@@ -329,7 +328,7 @@ func (r *MonitorMQTTResource) Read(ctx context.Context, req resource.ReadRequest
 	var mqttMonitor monitor.MQTT
 	err := r.client.GetMonitorAs(ctx, data.ID.ValueInt64(), &mqttMonitor)
 	if err != nil {
-		if errors.Is(err, kuma.ErrNotFound) {
+		if isNotFoundError(err) {
 			resp.State.RemoveResource(ctx)
 			return
 		}

--- a/internal/provider/resource_monitor_mysql.go
+++ b/internal/provider/resource_monitor_mysql.go
@@ -2,7 +2,6 @@ package provider
 
 import (
 	"context"
-	"errors"
 	"fmt"
 	"strconv"
 
@@ -182,7 +181,7 @@ func (r *MonitorMySQLResource) Read(ctx context.Context, req resource.ReadReques
 	var mysqlMonitor monitor.MySQL
 	err := r.client.GetMonitorAs(ctx, data.ID.ValueInt64(), &mysqlMonitor)
 	if err != nil {
-		if errors.Is(err, kuma.ErrNotFound) {
+		if isNotFoundError(err) {
 			resp.State.RemoveResource(ctx)
 			return
 		}

--- a/internal/provider/resource_monitor_ping.go
+++ b/internal/provider/resource_monitor_ping.go
@@ -2,7 +2,6 @@ package provider
 
 import (
 	"context"
-	"errors"
 	"fmt"
 	"strconv"
 
@@ -178,7 +177,7 @@ func (r *MonitorPingResource) Read(ctx context.Context, req resource.ReadRequest
 	err := r.client.GetMonitorAs(ctx, data.ID.ValueInt64(), &pingMonitor)
 	// Handle error.
 	if err != nil {
-		if errors.Is(err, kuma.ErrNotFound) {
+		if isNotFoundError(err) {
 			resp.State.RemoveResource(ctx)
 			return
 		}

--- a/internal/provider/resource_monitor_postgres.go
+++ b/internal/provider/resource_monitor_postgres.go
@@ -2,7 +2,6 @@ package provider
 
 import (
 	"context"
-	"errors"
 	"fmt"
 	"strconv"
 
@@ -182,7 +181,7 @@ func (r *MonitorPostgresResource) Read(ctx context.Context, req resource.ReadReq
 	err := r.client.GetMonitorAs(ctx, data.ID.ValueInt64(), &postgresMonitor)
 	// Handle error.
 	if err != nil {
-		if errors.Is(err, kuma.ErrNotFound) {
+		if isNotFoundError(err) {
 			resp.State.RemoveResource(ctx)
 			return
 		}

--- a/internal/provider/resource_monitor_push.go
+++ b/internal/provider/resource_monitor_push.go
@@ -2,7 +2,6 @@ package provider
 
 import (
 	"context"
-	"errors"
 	"fmt"
 	"strconv"
 
@@ -176,7 +175,7 @@ func (r *MonitorPushResource) Read(ctx context.Context, req resource.ReadRequest
 	err := r.client.GetMonitorAs(ctx, data.ID.ValueInt64(), &pushMonitor)
 	// Handle error.
 	if err != nil {
-		if errors.Is(err, kuma.ErrNotFound) {
+		if isNotFoundError(err) {
 			resp.State.RemoveResource(ctx)
 			return
 		}

--- a/internal/provider/resource_monitor_real_browser.go
+++ b/internal/provider/resource_monitor_real_browser.go
@@ -2,7 +2,6 @@ package provider
 
 import (
 	"context"
-	"errors"
 	"fmt"
 	"strconv"
 
@@ -335,7 +334,7 @@ func (r *MonitorRealBrowserResource) Read(ctx context.Context, req resource.Read
 	err := r.client.GetMonitorAs(ctx, data.ID.ValueInt64(), &realBrowserMonitor)
 	// Handle error.
 	if err != nil {
-		if errors.Is(err, kuma.ErrNotFound) {
+		if isNotFoundError(err) {
 			resp.State.RemoveResource(ctx)
 			return
 		}

--- a/internal/provider/resource_monitor_redis.go
+++ b/internal/provider/resource_monitor_redis.go
@@ -2,7 +2,6 @@ package provider
 
 import (
 	"context"
-	"errors"
 	"fmt"
 	"strconv"
 
@@ -174,7 +173,7 @@ func (r *MonitorRedisResource) Read(ctx context.Context, req resource.ReadReques
 	err := r.client.GetMonitorAs(ctx, data.ID.ValueInt64(), &redisMonitor)
 	// Handle error.
 	if err != nil {
-		if errors.Is(err, kuma.ErrNotFound) {
+		if isNotFoundError(err) {
 			resp.State.RemoveResource(ctx)
 			return
 		}

--- a/internal/provider/resource_monitor_snmp.go
+++ b/internal/provider/resource_monitor_snmp.go
@@ -2,7 +2,6 @@ package provider
 
 import (
 	"context"
-	"errors"
 	"fmt"
 	"strconv"
 
@@ -297,7 +296,7 @@ func (r *MonitorSNMPResource) Read(ctx context.Context, req resource.ReadRequest
 	var snmpMonitor monitor.SNMP
 	err := r.client.GetMonitorAs(ctx, data.ID.ValueInt64(), &snmpMonitor)
 	if err != nil {
-		if errors.Is(err, kuma.ErrNotFound) {
+		if isNotFoundError(err) {
 			resp.State.RemoveResource(ctx)
 			return
 		}

--- a/internal/provider/resource_monitor_sqlserver.go
+++ b/internal/provider/resource_monitor_sqlserver.go
@@ -2,7 +2,6 @@ package provider
 
 import (
 	"context"
-	"errors"
 	"fmt"
 	"strconv"
 
@@ -186,7 +185,7 @@ func (r *MonitorSQLServerResource) Read(
 	err := r.client.GetMonitorAs(ctx, data.ID.ValueInt64(), &sqlserverMonitor)
 	// Handle error.
 	if err != nil {
-		if errors.Is(err, kuma.ErrNotFound) {
+		if isNotFoundError(err) {
 			resp.State.RemoveResource(ctx)
 			return
 		}

--- a/internal/provider/resource_monitor_tcp_port.go
+++ b/internal/provider/resource_monitor_tcp_port.go
@@ -2,7 +2,6 @@ package provider
 
 import (
 	"context"
-	"errors"
 	"fmt"
 	"strconv"
 
@@ -187,7 +186,7 @@ func (r *MonitorTCPPortResource) Read(ctx context.Context, req resource.ReadRequ
 	err := r.client.GetMonitorAs(ctx, data.ID.ValueInt64(), &tcpPortMonitor)
 	// Handle error.
 	if err != nil {
-		if errors.Is(err, kuma.ErrNotFound) {
+		if isNotFoundError(err) {
 			resp.State.RemoveResource(ctx)
 			return
 		}

--- a/internal/provider/resource_status_page.go
+++ b/internal/provider/resource_status_page.go
@@ -2,7 +2,6 @@ package provider
 
 import (
 	"context"
-	"errors"
 	"fmt"
 	"strings"
 
@@ -369,7 +368,7 @@ func (r *StatusPageResource) Read(ctx context.Context, req resource.ReadRequest,
 
 	sp, err := r.client.GetStatusPage(ctx, data.Slug.ValueString())
 	if err != nil {
-		if errors.Is(err, kuma.ErrNotFound) {
+		if isNotFoundError(err) {
 			resp.State.RemoveResource(ctx)
 			return
 		}


### PR DESCRIPTION
Add `kuma.ErrNotFound` handling to all monitor and status page `Read()` functions. When a resource is deleted outside of Terraform (e.g. via the Uptime Kuma UI), the provider now removes the resource from state instead of returning an error, allowing Terraform to plan recreation.

This affects all 18 monitor resource types and the status page resource. The fix follows the existing pattern already used by tag, notification, maintenance, proxy, and docker host resources.

Closes #249