### PR TITLE
fix: default `server_url` to official Telegram API URL

### DIFF
--- a/internal/provider/resource_notification_telegram.go
+++ b/internal/provider/resource_notification_telegram.go
@@ -86,6 +86,8 @@ func (*NotificationTelegramResource) Schema(
 			"server_url": schema.StringAttribute{
 				MarkdownDescription: "Telegram server URL (optional, defaults to official Telegram API)",
 				Optional:            true,
+				Computed:            true,
+				Default:             stringdefault.StaticString("https://api.telegram.org"),
 			},
 			"send_silently": schema.BoolAttribute{
 				MarkdownDescription: "Send message silently",
@@ -232,7 +234,7 @@ func (r *NotificationTelegramResource) Read(
 	if telegram.ServerURL != "" {
 		data.ServerURL = types.StringValue(telegram.ServerURL)
 	} else {
-		data.ServerURL = types.StringNull()
+		data.ServerURL = types.StringValue("https://api.telegram.org")
 	}
 
 	data.SendSilently = types.BoolValue(telegram.SendSilently)

--- a/internal/provider/resource_notification_telegram.go
+++ b/internal/provider/resource_notification_telegram.go
@@ -20,6 +20,8 @@ import (
 	"github.com/breml/go-uptime-kuma-client/notification"
 )
 
+const telegramDefaultServerURL = "https://api.telegram.org"
+
 var (
 	_ resource.Resource                = &NotificationTelegramResource{}
 	_ resource.ResourceWithImportState = &NotificationTelegramResource{}
@@ -87,7 +89,10 @@ func (*NotificationTelegramResource) Schema(
 				MarkdownDescription: "Telegram server URL (optional, defaults to official Telegram API)",
 				Optional:            true,
 				Computed:            true,
-				Default:             stringdefault.StaticString("https://api.telegram.org"),
+				Default:             stringdefault.StaticString(telegramDefaultServerURL),
+				Validators: []validator.String{
+					stringvalidator.LengthAtLeast(1),
+				},
 			},
 			"send_silently": schema.BoolAttribute{
 				MarkdownDescription: "Send message silently",
@@ -234,7 +239,7 @@ func (r *NotificationTelegramResource) Read(
 	if telegram.ServerURL != "" {
 		data.ServerURL = types.StringValue(telegram.ServerURL)
 	} else {
-		data.ServerURL = types.StringValue("https://api.telegram.org")
+		data.ServerURL = types.StringValue(telegramDefaultServerURL)
 	}
 
 	data.SendSilently = types.BoolValue(telegram.SendSilently)

--- a/internal/provider/resource_notification_telegram_test.go
+++ b/internal/provider/resource_notification_telegram_test.go
@@ -75,6 +75,11 @@ func TestAccNotificationTelegramResource(t *testing.T) {
 						tfjsonpath.New("template_parse_mode"),
 						knownvalue.StringExact("HTML"),
 					),
+					statecheck.ExpectKnownValue(
+						"uptimekuma_notification_telegram.test",
+						tfjsonpath.New("server_url"),
+						knownvalue.StringExact("https://api.telegram.org"),
+					),
 				},
 			},
 			{


### PR DESCRIPTION
Add `Computed: true` and a schema default of `https://api.telegram.org` to the `server_url` attribute on `uptimekuma_notification_telegram`. Without the default the provider sent an empty string to the Uptime Kuma API, which differs from what the GUI populates when creating a Telegram notification manually.

The `Read()` function is also updated to return the default URL instead of null when the API returns an empty `ServerURL`.

Closes #285