### PR TITLE
fix: replace maldikhan/go.socket.io with breml/go.socket.io fork

### DIFF
--- a/.golangci.yml
+++ b/.golangci.yml
@@ -169,6 +169,11 @@ linters:
       # Default: false
       forbid-mutex: true
 
+    gomoddirectives:
+      # Allow local replace for the forked socket.io library (fixes race conditions, see #283).
+      replace-allow-list:
+        - github.com/maldikhan/go.socket.io
+
     errcheck:
       # Report about not checking of errors in type assertions: `a := b.(MyStruct)`.
       # Such cases aren't reported by default.

--- a/Taskfile.yml
+++ b/Taskfile.yml
@@ -35,14 +35,14 @@ tasks:
   test:
     desc: "Run tests"
     cmds:
-      - go test -v -shuffle=on -cover -timeout=120s -parallel=10 ./...
+      - go test -v -race -shuffle=on -cover -timeout=120s -parallel=10 ./...
 
   testacc:
     desc: "Run acceptance tests"
     env:
       TF_ACC: "1"
     cmds:
-      - go test -v -shuffle on -coverprofile coverage.out -timeout 600s ./...
+      - go test -v -race -shuffle on -coverprofile coverage.out -timeout 600s ./...
 
   testacc-cover-report:
     desc: "Generate acceptance tests coverage report"

--- a/go.mod
+++ b/go.mod
@@ -417,3 +417,5 @@ tool (
 )
 
 exclude github.com/docker/cli v28.2.2+incompatible
+
+replace github.com/maldikhan/go.socket.io => github.com/breml/go.socket.io v0.0.0-20260411142604-bddd3386d601

--- a/go.sum
+++ b/go.sum
@@ -172,6 +172,8 @@ github.com/breml/githooks v0.0.0-20260328191633-541253a9d3bd h1:Y8xr806ar32BjMXH
 github.com/breml/githooks v0.0.0-20260328191633-541253a9d3bd/go.mod h1:wSedAMuNx+ige9zqCTwIJufpRAenWlIgM6zNZ9Npae4=
 github.com/breml/go-uptime-kuma-client v0.3.0 h1:jRtY01RjZ0/3uXWCc0BFwYJpm++fGaThwV1UbHa2+bE=
 github.com/breml/go-uptime-kuma-client v0.3.0/go.mod h1:Rt2j/jLDuGgHzdMLnAryYBTRjorVJ6s0zqsMEsljqKk=
+github.com/breml/go.socket.io v0.0.0-20260411142604-bddd3386d601 h1:R6Es/0pyDBfjYaVIuq1xYkBrJrlvm4A8HVWMDvnIZhU=
+github.com/breml/go.socket.io v0.0.0-20260411142604-bddd3386d601/go.mod h1:H1EoWDJvqfV2WryM8F9og6ZkH7NsZDlHr0BRkKb58tY=
 github.com/breml/newline-after-block v0.0.0-20251225141726-84337171eef7 h1:ilIWXePccxYq7HvA/max1ZqS0kTkIB/sKzBPDneECts=
 github.com/breml/newline-after-block v0.0.0-20251225141726-84337171eef7/go.mod h1:zM/p1tEc+HETWeCNzspi+2C5H0D8I7dDClAtmt/fWBA=
 github.com/briandowns/spinner v1.23.2 h1:Zc6ecUnI+YzLmJniCfDNaMbW0Wid1d5+qcTq4L2FW8w=
@@ -569,8 +571,6 @@ github.com/lucasb-eyer/go-colorful v1.3.0 h1:2/yBRLdWBZKrf7gB40FoiKfAWYQ0lqNcbuQ
 github.com/lucasb-eyer/go-colorful v1.3.0/go.mod h1:R4dSotOR9KMtayYi1e77YzuveK+i7ruzyGqttikkLy0=
 github.com/macabu/inamedparam v0.2.0 h1:VyPYpOc10nkhI2qeNUdh3Zket4fcZjEWe35poddBCpE=
 github.com/macabu/inamedparam v0.2.0/go.mod h1:+Pee9/YfGe5LJ62pYXqB89lJ+0k5bsR8Wgz/C0Zlq3U=
-github.com/maldikhan/go.socket.io v0.1.1 h1:4yNNZRwbdcpw6NyXSXyLiQOMzNEXJyKsUZKaMihkRi0=
-github.com/maldikhan/go.socket.io v0.1.1/go.mod h1:H1EoWDJvqfV2WryM8F9og6ZkH7NsZDlHr0BRkKb58tY=
 github.com/maniartech/signals v1.3.1 h1:pT3dK6x5Un+B6L3ZLAKygEe+L49TClPreyT08vOoHXY=
 github.com/maniartech/signals v1.3.1/go.mod h1:AbE8Yy9ZjKCWNU/VhQ+0Ea9KOaTWHp6aOfdLBe5m1iM=
 github.com/manuelarte/embeddedstructfieldcheck v0.4.0 h1:3mAIyaGRtjK6EO9E73JlXLtiy7ha80b2ZVGyacxgfww=

--- a/internal/provider/connection_stability_test.go
+++ b/internal/provider/connection_stability_test.go
@@ -1,6 +1,7 @@
 package provider
 
 import (
+	"context"
 	"os"
 	"testing"
 	"time"
@@ -28,9 +29,10 @@ func TestAccConnectionStability(t *testing.T) {
 	const perConnTimeout = 30 * time.Second
 
 	for i := range iterations {
-		// Create a fresh connection each iteration to exercise the full
-		// transport negotiation path (HTTP long-polling → WebSocket upgrade).
-		ctx := t.Context()
+		// Wrap each iteration in a context.WithTimeout so that a regression
+		// (event dispatch hang after transport establishment) fails fast
+		// instead of blocking until the global go test -timeout fires.
+		ctx, cancel := context.WithTimeout(t.Context(), perConnTimeout)
 
 		kumaClient, err := kuma.New(
 			ctx,
@@ -41,10 +43,14 @@ func TestAccConnectionStability(t *testing.T) {
 			kuma.WithLogLevel(kuma.LogLevel(os.Getenv("SOCKETIO_LOG_LEVEL"))),
 		)
 		if err != nil {
+			cancel()
 			t.Fatalf("connection %d/%d failed: %v", i+1, iterations, err)
 		}
 
 		err = kumaClient.Disconnect()
+
+		cancel()
+
 		if err != nil {
 			t.Fatalf("disconnect %d/%d failed: %v", i+1, iterations, err)
 		}

--- a/internal/provider/connection_stability_test.go
+++ b/internal/provider/connection_stability_test.go
@@ -1,0 +1,52 @@
+package provider
+
+import (
+	"os"
+	"testing"
+	"time"
+
+	kuma "github.com/breml/go-uptime-kuma-client"
+	"github.com/hashicorp/terraform-plugin-testing/helper/resource"
+)
+
+// TestAccConnectionStability verifies that repeated sequential connections
+// to Uptime Kuma complete reliably. This exercises the Socket.IO transport
+// upgrade path (polling → websocket) multiple times, which amplifies the
+// probability of hitting the race conditions fixed in the breml/go.socket.io
+// fork (see issue #283). Combined with Go's -race detector, this test
+// catches unsynchronized access in the socket.io transport layer.
+func TestAccConnectionStability(t *testing.T) {
+	if os.Getenv(resource.EnvTfAcc) == "" {
+		t.Skip("TF_ACC not set — skipping acceptance test")
+	}
+
+	if endpoint == "" {
+		t.Fatal("endpoint not set — TestMain did not initialize the Docker container")
+	}
+
+	const iterations = 10
+	const perConnTimeout = 30 * time.Second
+
+	for i := range iterations {
+		// Create a fresh connection each iteration to exercise the full
+		// transport negotiation path (HTTP long-polling → WebSocket upgrade).
+		ctx := t.Context()
+
+		kumaClient, err := kuma.New(
+			ctx,
+			endpoint,
+			username,
+			password,
+			kuma.WithConnectTimeout(perConnTimeout),
+			kuma.WithLogLevel(kuma.LogLevel(os.Getenv("SOCKETIO_LOG_LEVEL"))),
+		)
+		if err != nil {
+			t.Fatalf("connection %d/%d failed: %v", i+1, iterations, err)
+		}
+
+		err = kumaClient.Disconnect()
+		if err != nil {
+			t.Fatalf("disconnect %d/%d failed: %v", i+1, iterations, err)
+		}
+	}
+}


### PR DESCRIPTION
## Summary

Replace the upstream `maldikhan/go.socket.io` dependency with the forked `breml/go.socket.io` to fix race conditions that cause `terraform plan` to hang with Uptime Kuma 2.2.0 (socket.io ~4.8.3).

## Changes

- Add `replace` directive in `go.mod` pointing to `breml/go.socket.io` (`dev` branch, commit `bddd338`)
- Allow the replace in `.golangci.yml` `gomoddirectives` settings

## Root Cause (from #283)

The `maldikhan/go.socket.io` library has race conditions in:

1. **Transport upgrade** (polling → websocket): `Send()` and `transportUpgrade()` access the transport field concurrently without synchronization. During the upgrade window, events are received at the transport layer but never dispatched to handlers.

2. **Handler map access**: `namespace.handlers` map is read/written concurrently without mutex protection.

3. **Data races**: `engine.io` client context field and polling transport `stopped` field accessed from multiple goroutines without synchronization.

## Fork Fixes

The fork includes two commits:

- **fix: resolve race conditions in transport upgrade and event dispatch** — Adds `sync.RWMutex` to engine.io client for transport field serialization and to socket.io namespace for handler map protection. Reorders `handleHandshake()` to complete the transport upgrade before invoking callbacks.

- **fix(engine.io/client): eliminate data races in client and polling transport** — Passes context as parameter to `messageLoop` goroutine. Replaces polling transport `stopped` bool with `atomic.Bool`.

Fixes #283