### PR TITLE
feat: add `timeout` attribute to `uptimekuma_monitor_ping`

### DIFF
--- a/docs/resources/monitor_ping.md
+++ b/docs/resources/monitor_ping.md
@@ -46,6 +46,7 @@ resource "uptimekuma_monitor_ping" "example" {
 - `resend_interval` (Number) Resend interval in seconds
 - `retry_interval` (Number) Retry interval in seconds
 - `tags` (Attributes Set) Set of tags assigned to this monitor (see [below for nested schema](#nestedatt--tags))
+- `timeout` (Number) Request timeout in seconds
 - `upside_down` (Boolean) Invert monitor status (treat DOWN as UP and vice versa)
 
 ### Read-Only

--- a/go.mod
+++ b/go.mod
@@ -3,7 +3,7 @@ module github.com/breml/terraform-provider-uptimekuma
 go 1.25.8
 
 require (
-	github.com/breml/go-uptime-kuma-client v0.3.1
+	github.com/breml/go-uptime-kuma-client v0.3.2
 	github.com/hashicorp/terraform-plugin-framework v1.19.0
 	github.com/hashicorp/terraform-plugin-go v0.31.0
 	github.com/hashicorp/terraform-plugin-log v0.10.0

--- a/go.sum
+++ b/go.sum
@@ -170,8 +170,8 @@ github.com/breml/errchkjson v0.4.1 h1:keFSS8D7A2T0haP9kzZTi7o26r7kE3vymjZNeNDRDw
 github.com/breml/errchkjson v0.4.1/go.mod h1:a23OvR6Qvcl7DG/Z4o0el6BRAjKnaReoPQFciAl9U3s=
 github.com/breml/githooks v0.0.0-20260328191633-541253a9d3bd h1:Y8xr806ar32BjMXH26TtNKI4gFvTf5oAgZqygoaaeF4=
 github.com/breml/githooks v0.0.0-20260328191633-541253a9d3bd/go.mod h1:wSedAMuNx+ige9zqCTwIJufpRAenWlIgM6zNZ9Npae4=
-github.com/breml/go-uptime-kuma-client v0.3.1 h1:yjBbI2a5iEQTm0Kksbm5u4Jl5dJvR+byV/c6h8QzpaA=
-github.com/breml/go-uptime-kuma-client v0.3.1/go.mod h1:QNfjHHvo4E0rTngFkU0LbQ9iChdbIwcFBowVIt4PRPE=
+github.com/breml/go-uptime-kuma-client v0.3.2 h1:4eyQap30N4ksew7wfp++NC8R6ubdrXh5kr4uluVWoy8=
+github.com/breml/go-uptime-kuma-client v0.3.2/go.mod h1:QNfjHHvo4E0rTngFkU0LbQ9iChdbIwcFBowVIt4PRPE=
 github.com/breml/go.socket.io v0.0.0-20260415184737-53d789da8f28 h1:2kD1B5TfvBKGL4zal8WWkAUOkv1XMEcbUcJbe6Nue0Y=
 github.com/breml/go.socket.io v0.0.0-20260415184737-53d789da8f28/go.mod h1:H1EoWDJvqfV2WryM8F9og6ZkH7NsZDlHr0BRkKb58tY=
 github.com/breml/newline-after-block v0.0.0-20251225141726-84337171eef7 h1:ilIWXePccxYq7HvA/max1ZqS0kTkIB/sKzBPDneECts=

--- a/internal/provider/resource_monitor_ping.go
+++ b/internal/provider/resource_monitor_ping.go
@@ -38,6 +38,7 @@ type MonitorPingResourceModel struct {
 
 	Hostname   types.String `tfsdk:"hostname"`
 	PacketSize types.Int64  `tfsdk:"packet_size"`
+	Timeout    types.Int64  `tfsdk:"timeout"`
 }
 
 // Metadata returns the metadata for the resource.
@@ -65,6 +66,15 @@ func (*MonitorPingResource) Schema(_ context.Context, _ resource.SchemaRequest, 
 				Default:             int64default.StaticInt64(56),
 				Validators: []validator.Int64{
 					int64validator.Between(1, 65500),
+				},
+			},
+			"timeout": schema.Int64Attribute{
+				MarkdownDescription: "Request timeout in seconds",
+				Optional:            true,
+				Computed:            true,
+				Default:             int64default.StaticInt64(48),
+				Validators: []validator.Int64{
+					int64validator.Between(1, 3600),
 				},
 			},
 		}),
@@ -104,6 +114,11 @@ func (r *MonitorPingResource) Create(ctx context.Context, req resource.CreateReq
 			Hostname:   data.Hostname.ValueString(),
 			PacketSize: int(data.PacketSize.ValueInt64()),
 		},
+	}
+
+	if !data.Timeout.IsNull() && !data.Timeout.IsUnknown() {
+		timeout := data.Timeout.ValueInt64()
+		pingMonitor.Timeout = &timeout
 	}
 
 	if !data.Description.IsNull() {
@@ -184,6 +199,12 @@ func (r *MonitorPingResource) Read(ctx context.Context, req resource.ReadRequest
 	data.Hostname = types.StringValue(pingMonitor.Hostname)
 	data.PacketSize = types.Int64Value(int64(pingMonitor.PacketSize))
 
+	if pingMonitor.Timeout != nil {
+		data.Timeout = types.Int64Value(*pingMonitor.Timeout)
+	} else {
+		data.Timeout = types.Int64Null()
+	}
+
 	if pingMonitor.Parent != nil {
 		data.Parent = types.Int64Value(*pingMonitor.Parent)
 	} else {
@@ -243,6 +264,11 @@ func (r *MonitorPingResource) Update(ctx context.Context, req resource.UpdateReq
 			Hostname:   data.Hostname.ValueString(),
 			PacketSize: int(data.PacketSize.ValueInt64()),
 		},
+	}
+
+	if !data.Timeout.IsNull() && !data.Timeout.IsUnknown() {
+		timeout := data.Timeout.ValueInt64()
+		pingMonitor.Timeout = &timeout
 	}
 
 	if !data.Description.IsNull() {

--- a/internal/provider/resource_monitor_ping_test.go
+++ b/internal/provider/resource_monitor_ping_test.go
@@ -23,12 +23,29 @@ func TestAccMonitorPingResource(t *testing.T) {
 		ProtoV6ProviderFactories: testAccProtoV6ProviderFactories,
 		Steps: []resource.TestStep{
 			{
+				Config:             testAccMonitorPingResourceConfigMinimal(name, hostname, 60, 56),
+				ExpectNonEmptyPlan: false,
+				ConfigStateChecks: []statecheck.StateCheck{
+					statecheck.ExpectKnownValue(
+						"uptimekuma_monitor_ping.test",
+						tfjsonpath.New("name"),
+						knownvalue.StringExact(name),
+					),
+					statecheck.ExpectKnownValue(
+						"uptimekuma_monitor_ping.test",
+						tfjsonpath.New("timeout"),
+						knownvalue.Int64Exact(48),
+					),
+				},
+			},
+			{
 				Config: testAccMonitorPingResourceConfigWithDescription(
 					name,
 					hostname,
 					description,
 					60,
 					56,
+					48,
 				),
 				ExpectNonEmptyPlan: false,
 				ConfigStateChecks: []statecheck.StateCheck{
@@ -59,13 +76,18 @@ func TestAccMonitorPingResource(t *testing.T) {
 					),
 					statecheck.ExpectKnownValue(
 						"uptimekuma_monitor_ping.test",
+						tfjsonpath.New("timeout"),
+						knownvalue.Int64Exact(48),
+					),
+					statecheck.ExpectKnownValue(
+						"uptimekuma_monitor_ping.test",
 						tfjsonpath.New("active"),
 						knownvalue.Bool(true),
 					),
 				},
 			},
 			{
-				Config: testAccMonitorPingResourceConfigWithDescription(nameUpdated, hostnameUpdated, "", 120, 64),
+				Config: testAccMonitorPingResourceConfigWithDescription(nameUpdated, hostnameUpdated, "", 120, 64, 30),
 				ConfigStateChecks: []statecheck.StateCheck{
 					statecheck.ExpectKnownValue(
 						"uptimekuma_monitor_ping.test",
@@ -89,6 +111,11 @@ func TestAccMonitorPingResource(t *testing.T) {
 					),
 					statecheck.ExpectKnownValue(
 						"uptimekuma_monitor_ping.test",
+						tfjsonpath.New("timeout"),
+						knownvalue.Int64Exact(30),
+					),
+					statecheck.ExpectKnownValue(
+						"uptimekuma_monitor_ping.test",
 						tfjsonpath.New("active"),
 						knownvalue.Bool(true),
 					),
@@ -105,7 +132,7 @@ func TestAccMonitorPingResource(t *testing.T) {
 
 func testAccMonitorPingResourceConfigWithDescription(
 	name string, hostname string, description string,
-	interval int64, packetSize int64,
+	interval int64, packetSize int64, timeout int64,
 ) string {
 	descField := ""
 	if description != "" {
@@ -119,7 +146,22 @@ resource "uptimekuma_monitor_ping" "test" {
 %[3]s
   interval    = %[4]d
   packet_size = %[5]d
+  timeout     = %[6]d
   active      = true
 }
-`, name, hostname, descField, interval, packetSize)
+`, name, hostname, descField, interval, packetSize, timeout)
+}
+
+func testAccMonitorPingResourceConfigMinimal(
+	name string, hostname string, interval int64, packetSize int64,
+) string {
+	return providerConfig() + fmt.Sprintf(`
+resource "uptimekuma_monitor_ping" "test" {
+  name        = %[1]q
+  hostname    = %[2]q
+  interval    = %[3]d
+  packet_size = %[4]d
+  active      = true
+}
+`, name, hostname, interval, packetSize)
 }


### PR DESCRIPTION
Add optional `timeout` attribute (default: 48s, range: 1-3600s) to the ping monitor resource. The Uptime Kuma server supports a timeout for ping monitors but the provider was not exposing it.

Depends on breml/go-uptime-kuma-client#230.

Closes #301