### PR TITLE
fix: make `timeout` an overall connection budget

### DIFF
--- a/docs/index.md
+++ b/docs/index.md
@@ -56,7 +56,8 @@ The provider supports managing the following resources:
 ### Optional
 
 - `endpoint` (String) Uptime Kuma endpoint. Can be set via `UPTIMEKUMA_ENDPOINT` environment variable.
-- `max_retries` (Number) Maximum number of connection retry attempts (default: `5`). Can be set via `UPTIMEKUMA_MAX_RETRIES` environment variable.
+- `max_retries` (Number) Maximum number of connection retry attempts (default: `3`). All retry attempts must complete within the overall `timeout` budget. Can be set via `UPTIMEKUMA_MAX_RETRIES` environment variable.
 - `password` (String, Sensitive) Uptime Kuma password. Can be set via `UPTIMEKUMA_PASSWORD` environment variable.
-- `timeout` (String) Connection timeout as a Go duration string (e.g. `30s`, `2m`). Defaults to `30s` if not specified. Can be set via `UPTIMEKUMA_TIMEOUT` environment variable.
+- `per_attempt_timeout` (String) Optional per-attempt connection timeout as a Go duration string (e.g. `5s`, `10s`). Caps the time spent on each individual connection attempt. The effective per-attempt timeout is the smaller of this value and the remaining `timeout` budget. When unset, each attempt may use the full remaining `timeout` budget. Can be set via `UPTIMEKUMA_PER_ATTEMPT_TIMEOUT` environment variable.
+- `timeout` (String) Overall connection timeout as a Go duration string (e.g. `30s`, `2m`). Bounds the total time spent attempting to connect to Uptime Kuma, including all retry attempts and backoff. Defaults to `30s` if not specified. Can be set via `UPTIMEKUMA_TIMEOUT` environment variable.
 - `username` (String) Uptime Kuma username. Can be set via `UPTIMEKUMA_USERNAME` environment variable.

--- a/internal/client/CLAUDE.md
+++ b/internal/client/CLAUDE.md
@@ -27,9 +27,19 @@ const defaultConnectTimeout = 30 * time.Second
 
 Applied automatically when no explicit `ConnectTimeout` is configured (or when a negative value is provided). This
 prevents the provider from hanging indefinitely when Uptime Kuma is unreachable. The `effectiveTimeout` helper resolves
-the configured value or falls back to `defaultConnectTimeout`. The resolved timeout is used for per-attempt timeouts
-(via `kuma.WithConnectTimeout`), and the overall retry deadline is computed as
-`ConnectTimeout * (MaxRetries + 1)` — giving each attempt a full timeout window.
+the configured value or falls back to `defaultConnectTimeout`. The resolved timeout is the **overall** budget for the
+whole connection process (across all retry attempts and backoff). Each individual attempt is bounded by
+`min(PerAttemptTimeout, remainingBudget)` via `kuma.WithConnectTimeout`. When `PerAttemptTimeout` is zero, each
+attempt may use the full remaining budget.
+
+### defaultMaxRetries
+
+```go
+const defaultMaxRetries = 3
+```
+
+Applied when no explicit `MaxRetries` is configured (or when a negative value is provided). All retry attempts must
+complete within the overall `ConnectTimeout` budget, so the default is intentionally small.
 
 ## Key Types
 
@@ -44,8 +54,9 @@ type Config struct {
     Password             string         // Optional: Login password
     LogLevel             int            // Optional: Socket.IO logging level
     EnableConnectionPool bool           // For acceptance tests, enables pooling
-    ConnectTimeout       time.Duration  // Per-attempt + overall timeout (default: 30s)
-    MaxRetries           int            // Max retry attempts (default: 5)
+    ConnectTimeout       time.Duration  // Overall timeout budget across all retry attempts (default: 30s)
+    PerAttemptTimeout    time.Duration  // Optional per-attempt cap; defaults to remaining ConnectTimeout budget
+    MaxRetries           int            // Max retry attempts (default: 3)
 }
 ```
 
@@ -54,8 +65,10 @@ type Config struct {
 - `Endpoint` is always required
 - `Username` and `Password` are both optional or both required (not one without the other)
 - `EnableConnectionPool` is enabled during acceptance tests to prevent "login: Too frequently" errors when pooling
-- `ConnectTimeout` defaults to `defaultConnectTimeout` (30s) when zero or negative; per-attempt timeout uses this value,
-  overall deadline is `ConnectTimeout * (MaxRetries + 1)`
+- `ConnectTimeout` defaults to `defaultConnectTimeout` (30s) when zero or negative; this value bounds the overall
+  connection process across all retry attempts and backoff
+- `PerAttemptTimeout` (when greater than zero) caps the time spent on each individual connection attempt; the effective
+  per-attempt timeout is `min(PerAttemptTimeout, remainingBudget)`
 
 ### Pool
 

--- a/internal/client/CLAUDE.md
+++ b/internal/client/CLAUDE.md
@@ -91,11 +91,13 @@ Used by the provider in both production and testing:
 
 ```go
 config := &Config{
-    Endpoint: "https://uptime-kuma.example.com",
-    Username: "admin",
-    Password: "password",
-    LogLevel: 0,
-    EnableConnectionPool: true,  // Always enabled by provider
+    Endpoint:             "https://uptime-kuma.example.com",
+    Username:             "admin",
+    Password:             "password",
+    LogLevel:             0,
+    EnableConnectionPool: true,           // Always enabled by provider
+    ConnectTimeout:       30 * time.Second, // overall budget; 0 uses defaultConnectTimeout
+    MaxRetries:           defaultMaxRetries, // 0 means no retries; negative uses defaultMaxRetries
 }
 
 client, err := client.New(ctx, config)
@@ -107,20 +109,18 @@ if err != nil {
 
 **Retry Logic:**
 
-- Maximum 5 retry attempts (6 total attempts including first try)
-- Exponential backoff: base delay 5 seconds, multiplied by 2^attempt
+- Maximum 3 retry attempts (4 total attempts including first try)
+- Exponential backoff: base delay 500ms, multiplied by 2^attempt
 - Jitter: ±20% randomization (0.8 to 1.2 multiplier)
-- Maximum backoff capped at 30 seconds
+- Backoff capped to the remaining overall `ConnectTimeout` budget
 - Respects context cancellation during backoff
 
-**Backoff Schedule:**
+**Backoff Schedule (with defaults):**
 
 - Attempt 1: Immediate
-- Attempt 2: ~5s (4-6s with jitter)
-- Attempt 3: ~10s (8-12s with jitter)
-- Attempt 4: ~20s (16-24s with jitter)
-- Attempt 5: ~30s (capped)
-- Attempt 6: ~30s (capped)
+- Attempt 2: ~500ms (400–600ms with jitter)
+- Attempt 3: ~1s (800ms–1.2s with jitter)
+- Attempt 4: ~2s (1.6–2.4s with jitter)
 
 ### Acceptance Tests
 
@@ -365,7 +365,7 @@ if err != nil {
 **Common Errors:**
 
 - `"endpoint is required"` - Config validation failure
-- `"failed after 6 attempts: ..."` - Connection retry exhaustion
+- `"failed after 4 attempts: ..."` - Connection retry exhaustion (with default `max_retries=3`)
 - `"connection cancelled: ..."` - Context cancellation during retry
 - `"pool config mismatch: ..."` - Credential confusion prevention
 

--- a/internal/client/client.go
+++ b/internal/client/client.go
@@ -12,11 +12,14 @@ import (
 )
 
 // defaultConnectTimeout is applied when no explicit ConnectTimeout is configured.
-// This prevents the provider from hanging indefinitely when Uptime Kuma is unreachable.
+// It bounds the overall connection process (across all retry attempts) to
+// prevent the provider from hanging indefinitely when Uptime Kuma is unreachable.
 const defaultConnectTimeout = 30 * time.Second
 
 // defaultMaxRetries is applied when no explicit MaxRetries is configured.
-const defaultMaxRetries = 5
+// It is intentionally small so that the default overall ConnectTimeout budget
+// can be split across a few quick attempts without requiring a large total wait.
+const defaultMaxRetries = 3
 
 // effectiveTimeout returns the configured timeout, or defaultConnectTimeout if
 // the configured value is zero or negative.
@@ -45,8 +48,15 @@ type Config struct {
 	Password             string
 	LogLevel             int
 	EnableConnectionPool bool
-	ConnectTimeout       time.Duration
-	MaxRetries           int
+	// ConnectTimeout is the overall connection budget across all retry
+	// attempts. It defaults to defaultConnectTimeout when zero or negative.
+	ConnectTimeout time.Duration
+	// PerAttemptTimeout, when greater than zero, caps the timeout used for
+	// each individual connection attempt. The effective per-attempt timeout
+	// is min(PerAttemptTimeout, remainingBudget). When zero, each attempt
+	// is allowed to use the full remaining ConnectTimeout budget.
+	PerAttemptTimeout time.Duration
+	MaxRetries        int
 }
 
 // New creates a new Uptime Kuma client with optional connection pooling.
@@ -65,13 +75,13 @@ func New(ctx context.Context, config *Config) (*kuma.Client, error) {
 }
 
 // newClientDirect creates a new direct connection with retry logic.
-// It resolves the effective timeout (using defaultConnectTimeout when
-// none is configured) and bounds each individual connection attempt
-// via kuma.WithConnectTimeout. The overall retry process is bounded
-// by a separate timer set to ConnectTimeout * (MaxRetries + 1).
-// The timer is kept separate from the context passed to kuma.New,
-// because the socket.io client stores that context for the lifetime
-// of the connection.
+// It resolves the effective overall timeout (using defaultConnectTimeout
+// when none is configured) and bounds the entire connection process by
+// that budget. Each individual attempt is bounded by
+// min(PerAttemptTimeout, remainingBudget) via kuma.WithConnectTimeout.
+// The overall budget is enforced by a separate timer, kept independent
+// of the context passed to kuma.New, because the socket.io client stores
+// that context for the lifetime of the connection.
 func newClientDirect(ctx context.Context, config *Config) (*kuma.Client, error) {
 	timeout := effectiveTimeout(config.ConnectTimeout)
 
@@ -79,33 +89,26 @@ func newClientDirect(ctx context.Context, config *Config) (*kuma.Client, error) 
 	resolved := *config
 	resolved.ConnectTimeout = timeout
 
-	opts := []kuma.Option{
-		kuma.WithLogLevel(config.LogLevel),
-		kuma.WithConnectTimeout(timeout),
-	}
-
-	return newClientDirectWithRetry(ctx, &resolved, opts)
+	return newClientDirectWithRetry(ctx, &resolved)
 }
 
 // newClientDirectWithRetry attempts to connect to Uptime Kuma with
 // exponential backoff retry logic. The retry loop is bounded by a
-// separate timer set to ConnectTimeout * (MaxRetries + 1), giving
-// each attempt a full ConnectTimeout window before the overall
-// deadline fires. The timer is intentionally not derived from ctx,
-// because ctx is passed into the socket.io client and controls the
-// connection lifetime — adding a deadline to it would kill the
-// connection after the timeout expires.
+// timer set to the overall ConnectTimeout budget. Each attempt's
+// per-attempt timeout is capped to the remaining budget so the
+// overall connection process never exceeds ConnectTimeout. The
+// timer is intentionally not derived from ctx, because ctx is passed
+// into the socket.io client and controls the connection lifetime —
+// adding a deadline to it would kill the connection after the
+// timeout expires.
 func newClientDirectWithRetry(
 	ctx context.Context,
 	config *Config,
-	opts []kuma.Option,
 ) (*kuma.Client, error) {
 	maxRetries := effectiveMaxRetries(config.MaxRetries)
 
-	// Overall deadline = ConnectTimeout * (MaxRetries + 1), so each
-	// attempt gets a full ConnectTimeout window before the deadline fires.
-	overallDeadline := config.ConnectTimeout * time.Duration(maxRetries+1)
-	timer := time.NewTimer(overallDeadline)
+	overallDeadline := time.Now().Add(config.ConnectTimeout)
+	timer := time.NewTimer(time.Until(overallDeadline))
 	defer timer.Stop()
 
 	deadline := timer.C
@@ -124,6 +127,16 @@ func newClientDirectWithRetry(
 		default:
 		}
 
+		attemptTimeout := remainingAttemptTimeout(overallDeadline, config.PerAttemptTimeout)
+		if attemptTimeout <= 0 {
+			return nil, newTimeoutError(attempt, err)
+		}
+
+		opts := []kuma.Option{
+			kuma.WithLogLevel(config.LogLevel),
+			kuma.WithConnectTimeout(attemptTimeout),
+		}
+
 		kumaClient, err = kuma.New(
 			ctx,
 			config.Endpoint,
@@ -139,11 +152,20 @@ func newClientDirectWithRetry(
 			break
 		}
 
-		// Exponential backoff with jitter.
+		// Exponential backoff with jitter, capped to remaining budget.
 		backoff := float64(baseDelay) * math.Pow(2, float64(attempt))
 		//nolint:gosec // Not for cryptographic use, only for jitter in backoff.
 		jitter := rand.Float64()*0.4 + 0.8 // 0.8 to 1.2 (±20%)
 		sleepDuration := min(time.Duration(backoff*jitter), 30*time.Second)
+
+		remaining := time.Until(overallDeadline)
+		if remaining <= 0 {
+			return nil, newTimeoutError(attempt+1, err)
+		}
+
+		if sleepDuration > remaining {
+			sleepDuration = remaining
+		}
 
 		select {
 		case <-ctx.Done():
@@ -158,6 +180,22 @@ func newClientDirectWithRetry(
 	}
 
 	return nil, fmt.Errorf("failed after %d attempts: %w", maxRetries+1, err)
+}
+
+// remainingAttemptTimeout returns the timeout to use for the next attempt.
+// It is bounded by the remaining overall budget, and additionally capped to
+// perAttempt when perAttempt is greater than zero.
+func remainingAttemptTimeout(overallDeadline time.Time, perAttempt time.Duration) time.Duration {
+	remaining := time.Until(overallDeadline)
+	if remaining <= 0 {
+		return 0
+	}
+
+	if perAttempt > 0 && perAttempt < remaining {
+		return perAttempt
+	}
+
+	return remaining
 }
 
 // newTimeoutError creates a timeout error message. If lastErr is not nil,

--- a/internal/client/client.go
+++ b/internal/client/client.go
@@ -32,9 +32,9 @@ func effectiveTimeout(configured time.Duration) time.Duration {
 }
 
 // effectiveMaxRetries returns the configured max retries, or defaultMaxRetries if
-// the configured value is zero or negative.
+// the configured value is negative. Zero is treated as "no retries" (one attempt total).
 func effectiveMaxRetries(configured int) int {
-	if configured > 0 {
+	if configured >= 0 {
 		return configured
 	}
 

--- a/internal/client/client_test.go
+++ b/internal/client/client_test.go
@@ -69,9 +69,16 @@ func TestEffectiveTimeout_Negative(t *testing.T) {
 }
 
 func TestEffectiveMaxRetries_Default(t *testing.T) {
-	got := effectiveMaxRetries(0)
+	got := effectiveMaxRetries(-1)
 	if got != defaultMaxRetries {
 		t.Errorf("expected %d, got %d", defaultMaxRetries, got)
+	}
+}
+
+func TestEffectiveMaxRetries_Zero(t *testing.T) {
+	got := effectiveMaxRetries(0)
+	if got != 0 {
+		t.Errorf("expected 0 for explicitly-zero max retries, got %d", got)
 	}
 }
 

--- a/internal/client/client_test.go
+++ b/internal/client/client_test.go
@@ -89,6 +89,44 @@ func TestEffectiveMaxRetries_Negative(t *testing.T) {
 	}
 }
 
+func TestRemainingAttemptTimeout_NoCap(t *testing.T) {
+	deadline := time.Now().Add(5 * time.Second)
+
+	got := remainingAttemptTimeout(deadline, 0)
+	if got <= 0 || got > 5*time.Second {
+		t.Errorf("expected value within (0,5s], got %s", got)
+	}
+}
+
+func TestRemainingAttemptTimeout_CapApplied(t *testing.T) {
+	deadline := time.Now().Add(10 * time.Second)
+	perAttempt := 2 * time.Second
+
+	got := remainingAttemptTimeout(deadline, perAttempt)
+	if got != perAttempt {
+		t.Errorf("expected %s, got %s", perAttempt, got)
+	}
+}
+
+func TestRemainingAttemptTimeout_CapLargerThanRemaining(t *testing.T) {
+	deadline := time.Now().Add(1 * time.Second)
+	perAttempt := 30 * time.Second
+
+	got := remainingAttemptTimeout(deadline, perAttempt)
+	if got <= 0 || got > 1*time.Second {
+		t.Errorf("expected value within (0,1s], got %s", got)
+	}
+}
+
+func TestRemainingAttemptTimeout_DeadlinePassed(t *testing.T) {
+	deadline := time.Now().Add(-1 * time.Second)
+
+	got := remainingAttemptTimeout(deadline, 5*time.Second)
+	if got != 0 {
+		t.Errorf("expected 0 when deadline already passed, got %s", got)
+	}
+}
+
 func TestNew_EmptyEndpoint(t *testing.T) {
 	config := &Config{
 		Endpoint: "",
@@ -169,12 +207,11 @@ func TestNewClientDirect_ConnectTimeoutLimitsOverallDuration(t *testing.T) {
 	// Use a local listener that accepts TCP connections but never
 	// completes the socket.io handshake. This is deterministic and
 	// independent of network configuration, unlike TEST-NET addresses.
-	// ConnectTimeout bounds per-attempt timeout; the overall deadline
-	// is ConnectTimeout * (MaxRetries + 1). The timer is separate from
-	// the context because the socket.io client stores it for the
-	// connection lifetime.
+	// ConnectTimeout bounds the overall connection process across all
+	// retry attempts. The timer is separate from the context because
+	// the socket.io client stores it for the connection lifetime.
 	endpoint := startDeadEndListener(t)
-	connectTimeout := 2 * time.Second
+	connectTimeout := 3 * time.Second
 
 	config := &Config{
 		Endpoint:       endpoint,
@@ -195,9 +232,10 @@ func TestNewClientDirect_ConnectTimeoutLimitsOverallDuration(t *testing.T) {
 		t.Fatal("expected error for unreachable endpoint, got nil")
 	}
 
-	// Overall deadline = ConnectTimeout * (MaxRetries + 1) = 2s * 3 = 6s.
-	// Allow some slack for scheduling.
-	upperBound := connectTimeout*time.Duration(config.MaxRetries+1) + 2*time.Second
+	// Overall deadline equals ConnectTimeout (total budget). Allow some
+	// slack for scheduling and for the in-flight kuma.New attempt to
+	// observe the deadline.
+	upperBound := connectTimeout + 2*time.Second
 	if elapsed > upperBound {
 		t.Errorf("expected connection to fail within %s, took %s", upperBound, elapsed)
 	}
@@ -207,21 +245,22 @@ func TestNewClientDirect_ConnectTimeoutLimitsOverallDuration(t *testing.T) {
 	}
 }
 
-func TestNewClientDirect_MaxRetriesLimitsAttempts(t *testing.T) {
-	// Verify that MaxRetries limits the number of connection attempts.
-	// Use a dead-end listener with a short ConnectTimeout so each
-	// attempt fails quickly. With MaxRetries=2 and ConnectTimeout=1s,
-	// the overall deadline is 1s * 3 = 3s. The test verifies that all
-	// 3 attempts run within that window.
+func TestNewClientDirect_PerAttemptTimeoutLimitsAttempts(t *testing.T) {
+	// Verify that PerAttemptTimeout caps each individual attempt so that
+	// multiple retry attempts can be performed within the overall
+	// ConnectTimeout budget. With PerAttemptTimeout=500ms and overall
+	// ConnectTimeout=3s, the loop should perform several attempts and
+	// still finish within ~3s.
 	endpoint := startDeadEndListener(t)
 
 	config := &Config{
-		Endpoint:       endpoint,
-		Username:       "admin",
-		Password:       "secret",
-		ConnectTimeout: 1 * time.Second,
-		MaxRetries:     2,
-		LogLevel:       kuma.LogLevel(os.Getenv("SOCKETIO_LOG_LEVEL")),
+		Endpoint:          endpoint,
+		Username:          "admin",
+		Password:          "secret",
+		ConnectTimeout:    3 * time.Second,
+		PerAttemptTimeout: 500 * time.Millisecond,
+		MaxRetries:        5,
+		LogLevel:          kuma.LogLevel(os.Getenv("SOCKETIO_LOG_LEVEL")),
 	}
 
 	start := time.Now()
@@ -234,8 +273,8 @@ func TestNewClientDirect_MaxRetriesLimitsAttempts(t *testing.T) {
 		t.Fatal("expected error for dead-end endpoint, got nil")
 	}
 
-	// Overall deadline = 1s * (2 + 1) = 3s. Allow some slack.
-	upperBound := config.ConnectTimeout*time.Duration(config.MaxRetries+1) + 2*time.Second
+	// Overall deadline equals ConnectTimeout. Allow some slack.
+	upperBound := config.ConnectTimeout + 2*time.Second
 	if elapsed > upperBound {
 		t.Errorf("expected connection to fail within %s, took %s", upperBound, elapsed)
 	}

--- a/internal/client/pool.go
+++ b/internal/client/pool.go
@@ -125,9 +125,10 @@ func (p *Pool) Close() error {
 }
 
 // configMatches checks if the provided config matches the pool's config.
-// Only connection-critical fields (endpoint, credentials, timeout, max_retries) are compared.
-// LogLevel and EnableConnectionPool are intentionally excluded as they don't
-// affect the connection identity - the first connection's LogLevel is used.
+// Only connection-critical fields (endpoint, credentials, timeout,
+// per_attempt_timeout, max_retries) are compared. LogLevel and
+// EnableConnectionPool are intentionally excluded as they don't affect the
+// connection identity - the first connection's LogLevel is used.
 func (p *Pool) configMatches(config *Config) bool {
 	if p.config == nil {
 		return false

--- a/internal/client/pool.go
+++ b/internal/client/pool.go
@@ -47,15 +47,18 @@ func (p *Pool) GetOrCreate(ctx context.Context, config *Config) (*kuma.Client, e
 	if p.client != nil {
 		if !p.configMatches(config) {
 			return nil, fmt.Errorf(
-				"pool config mismatch: existing endpoint=%q username=%q timeout=%s max_retries=%d,"+
-					" requested endpoint=%q username=%q timeout=%s max_retries=%d",
+				"pool config mismatch: existing endpoint=%q username=%q timeout=%s per_attempt_timeout=%s"+
+					" max_retries=%d, requested endpoint=%q username=%q timeout=%s per_attempt_timeout=%s"+
+					" max_retries=%d",
 				p.config.Endpoint,
 				p.config.Username,
 				effectiveTimeout(p.config.ConnectTimeout),
+				p.config.PerAttemptTimeout,
 				effectiveMaxRetries(p.config.MaxRetries),
 				config.Endpoint,
 				config.Username,
 				effectiveTimeout(config.ConnectTimeout),
+				config.PerAttemptTimeout,
 				effectiveMaxRetries(config.MaxRetries),
 			)
 		}
@@ -134,6 +137,7 @@ func (p *Pool) configMatches(config *Config) bool {
 		p.config.Username == config.Username &&
 		p.config.Password == config.Password &&
 		effectiveTimeout(p.config.ConnectTimeout) == effectiveTimeout(config.ConnectTimeout) &&
+		p.config.PerAttemptTimeout == config.PerAttemptTimeout &&
 		effectiveMaxRetries(p.config.MaxRetries) == effectiveMaxRetries(config.MaxRetries)
 }
 

--- a/internal/client/pool_test.go
+++ b/internal/client/pool_test.go
@@ -103,6 +103,16 @@ func TestPool_ConfigMatches(t *testing.T) {
 			},
 			expected: false,
 		},
+		{
+			name: "different per attempt timeout",
+			config: &Config{
+				Endpoint:          "http://localhost:3001",
+				Username:          "admin",
+				Password:          "secret",
+				PerAttemptTimeout: 5 * time.Second,
+			},
+			expected: false,
+		},
 	}
 
 	for _, tc := range tests {
@@ -146,20 +156,20 @@ func TestPool_ConfigMatches_EffectiveMaxRetries(t *testing.T) {
 			Endpoint:   "http://localhost:3001",
 			Username:   "admin",
 			Password:   "secret",
-			MaxRetries: 0, // resolves to defaultMaxRetries (5)
+			MaxRetries: 0, // resolves to defaultMaxRetries
 		},
 	}
 
-	// Explicitly passing 5 should match zero (both resolve to 5).
+	// Explicitly passing defaultMaxRetries should match zero (both resolve to the same value).
 	config := &Config{
 		Endpoint:   "http://localhost:3001",
 		Username:   "admin",
 		Password:   "secret",
-		MaxRetries: 5,
+		MaxRetries: defaultMaxRetries,
 	}
 
 	if !pool.configMatches(config) {
-		t.Error("expected configMatches to return true for MaxRetries=0 vs 5")
+		t.Errorf("expected configMatches to return true for MaxRetries=0 vs %d", defaultMaxRetries)
 	}
 }
 

--- a/internal/client/pool_test.go
+++ b/internal/client/pool_test.go
@@ -156,20 +156,28 @@ func TestPool_ConfigMatches_EffectiveMaxRetries(t *testing.T) {
 			Endpoint:   "http://localhost:3001",
 			Username:   "admin",
 			Password:   "secret",
-			MaxRetries: 0, // resolves to defaultMaxRetries
+			MaxRetries: defaultMaxRetries, // explicit default value, as the provider always sets
 		},
 	}
 
-	// Explicitly passing defaultMaxRetries should match zero (both resolve to the same value).
-	config := &Config{
+	// Same explicit value should match.
+	if !pool.configMatches(&Config{
 		Endpoint:   "http://localhost:3001",
 		Username:   "admin",
 		Password:   "secret",
 		MaxRetries: defaultMaxRetries,
+	}) {
+		t.Errorf("expected configMatches to return true for MaxRetries=%d vs %d", defaultMaxRetries, defaultMaxRetries)
 	}
 
-	if !pool.configMatches(config) {
-		t.Errorf("expected configMatches to return true for MaxRetries=0 vs %d", defaultMaxRetries)
+	// MaxRetries=0 (no retries) must NOT match defaultMaxRetries.
+	if pool.configMatches(&Config{
+		Endpoint:   "http://localhost:3001",
+		Username:   "admin",
+		Password:   "secret",
+		MaxRetries: 0,
+	}) {
+		t.Errorf("expected configMatches to return false for MaxRetries=%d vs MaxRetries=0", defaultMaxRetries)
 	}
 }
 

--- a/internal/provider/provider.go
+++ b/internal/provider/provider.go
@@ -200,6 +200,18 @@ func parseClientOptions(
 		return opts
 	}
 
+	if opts.perAttemptTimeout > 0 && opts.connectTimeout > 0 && opts.perAttemptTimeout >= opts.connectTimeout {
+		resp.Diagnostics.AddWarning(
+			"per_attempt_timeout has no effect",
+			fmt.Sprintf(
+				"per_attempt_timeout (%s) is greater than or equal to timeout (%s); "+
+					"each attempt is already bounded by the remaining overall budget, "+
+					"so per_attempt_timeout will never be applied",
+				opts.perAttemptTimeout, opts.connectTimeout,
+			),
+		)
+	}
+
 	opts.maxRetries = defaultMaxRetries
 
 	if !data.MaxRetries.IsNull() {

--- a/internal/provider/provider.go
+++ b/internal/provider/provider.go
@@ -86,9 +86,12 @@ func (*UptimeKumaProvider) Schema(_ context.Context, _ provider.SchemaRequest, r
 				Optional: true,
 			},
 			"max_retries": schema.Int64Attribute{
-				MarkdownDescription: "Maximum number of connection retry attempts (default: `3`). " +
-					"All retry attempts must complete within the overall `timeout` budget. " +
-					"Can be set via `UPTIMEKUMA_MAX_RETRIES` environment variable.",
+				MarkdownDescription: fmt.Sprintf(
+					"Maximum number of connection retry attempts (default: `%d`). "+
+						"All retry attempts must complete within the overall `timeout` budget. "+
+						"Can be set via `UPTIMEKUMA_MAX_RETRIES` environment variable.",
+					defaultMaxRetries,
+				),
 				Optional: true,
 			},
 		},
@@ -215,8 +218,10 @@ func parseClientOptions(
 	return opts
 }
 
-// defaultMaxRetries mirrors the client package default and is used here only
-// to surface the same value back to users via the provider schema description.
+// defaultMaxRetries mirrors the client package default. It is used both as
+// the fallback in parseClientOptions when the user does not provide an
+// explicit value, and to render the value in the `max_retries` schema
+// description so the documented default cannot drift from the runtime one.
 const defaultMaxRetries = 3
 
 // parseDurationAttribute parses a Go duration string from a Terraform string

--- a/internal/provider/provider.go
+++ b/internal/provider/provider.go
@@ -35,11 +35,12 @@ type UptimeKumaProvider struct {
 
 // UptimeKumaProviderModel describes the provider data model.
 type UptimeKumaProviderModel struct {
-	Endpoint   types.String `tfsdk:"endpoint"`
-	Username   types.String `tfsdk:"username"`
-	Password   types.String `tfsdk:"password"`
-	Timeout    types.String `tfsdk:"timeout"`
-	MaxRetries types.Int64  `tfsdk:"max_retries"`
+	Endpoint          types.String `tfsdk:"endpoint"`
+	Username          types.String `tfsdk:"username"`
+	Password          types.String `tfsdk:"password"`
+	Timeout           types.String `tfsdk:"timeout"`
+	PerAttemptTimeout types.String `tfsdk:"per_attempt_timeout"`
+	MaxRetries        types.Int64  `tfsdk:"max_retries"`
 }
 
 // Metadata returns the metadata for the provider.
@@ -70,13 +71,23 @@ func (*UptimeKumaProvider) Schema(_ context.Context, _ provider.SchemaRequest, r
 				Sensitive:           true,
 			},
 			"timeout": schema.StringAttribute{
-				MarkdownDescription: "Connection timeout as a Go duration string (e.g. `30s`, `2m`). " +
-					"Defaults to `30s` if not specified. " +
+				MarkdownDescription: "Overall connection timeout as a Go duration string (e.g. `30s`, `2m`). " +
+					"Bounds the total time spent attempting to connect to Uptime Kuma, including all retry " +
+					"attempts and backoff. Defaults to `30s` if not specified. " +
 					"Can be set via `UPTIMEKUMA_TIMEOUT` environment variable.",
 				Optional: true,
 			},
+			"per_attempt_timeout": schema.StringAttribute{
+				MarkdownDescription: "Optional per-attempt connection timeout as a Go duration string " +
+					"(e.g. `5s`, `10s`). Caps the time spent on each individual connection attempt. The " +
+					"effective per-attempt timeout is the smaller of this value and the remaining `timeout` " +
+					"budget. When unset, each attempt may use the full remaining `timeout` budget. " +
+					"Can be set via `UPTIMEKUMA_PER_ATTEMPT_TIMEOUT` environment variable.",
+				Optional: true,
+			},
 			"max_retries": schema.Int64Attribute{
-				MarkdownDescription: "Maximum number of connection retry attempts (default: `5`). " +
+				MarkdownDescription: "Maximum number of connection retry attempts (default: `3`). " +
+					"All retry attempts must complete within the overall `timeout` budget. " +
 					"Can be set via `UPTIMEKUMA_MAX_RETRIES` environment variable.",
 				Optional: true,
 			},
@@ -126,7 +137,7 @@ func (*UptimeKumaProvider) Configure(
 		return
 	}
 
-	connectTimeout, maxRetries := parseClientOptions(&data, resp)
+	opts := parseClientOptions(&data, resp)
 	if resp.Diagnostics.HasError() {
 		return
 	}
@@ -137,8 +148,9 @@ func (*UptimeKumaProvider) Configure(
 		Password:             data.Password.ValueString(),
 		EnableConnectionPool: true,
 		LogLevel:             kuma.LogLevel(os.Getenv("SOCKETIO_LOG_LEVEL")),
-		ConnectTimeout:       connectTimeout,
-		MaxRetries:           maxRetries,
+		ConnectTimeout:       opts.connectTimeout,
+		PerAttemptTimeout:    opts.perAttemptTimeout,
+		MaxRetries:           opts.maxRetries,
 	})
 	if err != nil {
 		resp.Diagnostics.AddError("failed to create client", err.Error())
@@ -160,51 +172,86 @@ func (*UptimeKumaProvider) Configure(
 	resp.ResourceData = pd
 }
 
-// parseClientOptions extracts and validates timeout and max_retries from the provider model.
+// clientOptions holds parsed and validated provider connection options.
+type clientOptions struct {
+	connectTimeout    time.Duration
+	perAttemptTimeout time.Duration
+	maxRetries        int
+}
+
+// parseClientOptions extracts and validates timeout, per_attempt_timeout and
+// max_retries from the provider model.
 func parseClientOptions(
 	data *UptimeKumaProviderModel,
 	resp *provider.ConfigureResponse,
-) (connectTimeout time.Duration, maxRetries int) {
-	timeoutStr := strings.TrimSpace(data.Timeout.ValueString())
-	if !data.Timeout.IsNull() && timeoutStr != "" {
-		var parseErr error
+) clientOptions {
+	var opts clientOptions
 
-		connectTimeout, parseErr = time.ParseDuration(timeoutStr)
-		if parseErr != nil {
-			resp.Diagnostics.AddError(
-				"invalid timeout",
-				fmt.Sprintf("failed to parse timeout %q: %s", data.Timeout.ValueString(), parseErr.Error()),
-			)
-
-			return 0, 0
-		}
-
-		if connectTimeout < 0 {
-			resp.Diagnostics.AddError(
-				"invalid timeout",
-				fmt.Sprintf("timeout must be non-negative, got %s", connectTimeout),
-			)
-
-			return 0, 0
-		}
+	opts.connectTimeout = parseDurationAttribute(data.Timeout, "timeout", resp)
+	if resp.Diagnostics.HasError() {
+		return opts
 	}
 
-	maxRetries = 5
+	opts.perAttemptTimeout = parseDurationAttribute(data.PerAttemptTimeout, "per_attempt_timeout", resp)
+	if resp.Diagnostics.HasError() {
+		return opts
+	}
+
+	opts.maxRetries = defaultMaxRetries
 
 	if !data.MaxRetries.IsNull() {
-		maxRetries = int(data.MaxRetries.ValueInt64())
+		opts.maxRetries = int(data.MaxRetries.ValueInt64())
 	}
 
-	if maxRetries < 0 {
+	if opts.maxRetries < 0 {
 		resp.Diagnostics.AddError(
 			"invalid max_retries",
-			fmt.Sprintf("max_retries must be non-negative, got %d", maxRetries),
+			fmt.Sprintf("max_retries must be non-negative, got %d", opts.maxRetries),
 		)
 
-		return 0, 0
+		return clientOptions{}
 	}
 
-	return connectTimeout, maxRetries
+	return opts
+}
+
+// defaultMaxRetries mirrors the client package default and is used here only
+// to surface the same value back to users via the provider schema description.
+const defaultMaxRetries = 3
+
+// parseDurationAttribute parses a Go duration string from a Terraform string
+// attribute. Empty/null values yield a zero duration (meaning "use the default").
+// Negative values produce a diagnostic error.
+func parseDurationAttribute(
+	attr types.String,
+	name string,
+	resp *provider.ConfigureResponse,
+) time.Duration {
+	value := strings.TrimSpace(attr.ValueString())
+	if attr.IsNull() || value == "" {
+		return 0
+	}
+
+	parsed, err := time.ParseDuration(value)
+	if err != nil {
+		resp.Diagnostics.AddError(
+			fmt.Sprintf("invalid %s", name),
+			fmt.Sprintf("failed to parse %s %q: %s", name, attr.ValueString(), err.Error()),
+		)
+
+		return 0
+	}
+
+	if parsed < 0 {
+		resp.Diagnostics.AddError(
+			fmt.Sprintf("invalid %s", name),
+			fmt.Sprintf("%s must be non-negative, got %s", name, parsed),
+		)
+
+		return 0
+	}
+
+	return parsed
 }
 
 // applyEnvironmentDefaults applies environment variable defaults to the provider model.
@@ -228,6 +275,11 @@ func applyEnvironmentDefaults(data *UptimeKumaProviderModel, resp *provider.Conf
 	envTimeout := os.Getenv("UPTIMEKUMA_TIMEOUT")
 	if data.Timeout.IsNull() && envTimeout != "" {
 		data.Timeout = types.StringValue(envTimeout)
+	}
+
+	envPerAttemptTimeout := os.Getenv("UPTIMEKUMA_PER_ATTEMPT_TIMEOUT")
+	if data.PerAttemptTimeout.IsNull() && envPerAttemptTimeout != "" {
+		data.PerAttemptTimeout = types.StringValue(envPerAttemptTimeout)
 	}
 
 	envMaxRetries := os.Getenv("UPTIMEKUMA_MAX_RETRIES")

--- a/internal/provider/provider_test.go
+++ b/internal/provider/provider_test.go
@@ -423,6 +423,43 @@ data "uptimekuma_tag" "test" {}
 	})
 }
 
+func TestApplyEnvironmentDefaults_PerAttemptTimeout(t *testing.T) {
+	t.Setenv("UPTIMEKUMA_PER_ATTEMPT_TIMEOUT", "5s")
+
+	model := UptimeKumaProviderModel{
+		Endpoint:          types.StringNull(),
+		Username:          types.StringNull(),
+		Password:          types.StringNull(),
+		Timeout:           types.StringNull(),
+		PerAttemptTimeout: types.StringNull(),
+	}
+
+	applyEnvironmentDefaults(&model, &provider.ConfigureResponse{})
+
+	if model.PerAttemptTimeout.ValueString() != "5s" {
+		t.Errorf("expected per_attempt_timeout %q from env, got %q", "5s", model.PerAttemptTimeout.ValueString())
+	}
+}
+
+func TestApplyEnvironmentDefaults_PerAttemptTimeoutConfigOverridesEnv(t *testing.T) {
+	t.Setenv("UPTIMEKUMA_PER_ATTEMPT_TIMEOUT", "5s")
+
+	model := UptimeKumaProviderModel{
+		Endpoint:          types.StringNull(),
+		Username:          types.StringNull(),
+		Password:          types.StringNull(),
+		Timeout:           types.StringNull(),
+		PerAttemptTimeout: types.StringValue("10s"),
+	}
+
+	applyEnvironmentDefaults(&model, &provider.ConfigureResponse{})
+
+	if model.PerAttemptTimeout.ValueString() != "10s" {
+		t.Errorf("expected config per_attempt_timeout %q to take precedence, got %q",
+			"10s", model.PerAttemptTimeout.ValueString())
+	}
+}
+
 func TestAccProviderInvalidTimeout(t *testing.T) {
 	resource.Test(t, resource.TestCase{
 		ProtoV6ProviderFactories: testAccProtoV6ProviderFactories,
@@ -456,6 +493,44 @@ provider "uptimekuma" {
 data "uptimekuma_tag" "test" {}
 `,
 				ExpectError: regexp.MustCompile(`timeout must be non-negative`),
+			},
+		},
+	})
+}
+
+func TestAccProviderInvalidPerAttemptTimeout(t *testing.T) {
+	resource.Test(t, resource.TestCase{
+		ProtoV6ProviderFactories: testAccProtoV6ProviderFactories,
+		Steps: []resource.TestStep{
+			{
+				Config: `
+provider "uptimekuma" {
+  endpoint            = "http://localhost:3001"
+  per_attempt_timeout = "notaduration"
+}
+
+data "uptimekuma_tag" "test" {}
+`,
+				ExpectError: regexp.MustCompile(`failed to parse per_attempt_timeout`),
+			},
+		},
+	})
+}
+
+func TestAccProviderNegativePerAttemptTimeout(t *testing.T) {
+	resource.Test(t, resource.TestCase{
+		ProtoV6ProviderFactories: testAccProtoV6ProviderFactories,
+		Steps: []resource.TestStep{
+			{
+				Config: `
+provider "uptimekuma" {
+  endpoint            = "http://localhost:3001"
+  per_attempt_timeout = "-5s"
+}
+
+data "uptimekuma_tag" "test" {}
+`,
+				ExpectError: regexp.MustCompile(`per_attempt_timeout must be non-negative`),
 			},
 		},
 	})

--- a/internal/provider/provider_test.go
+++ b/internal/provider/provider_test.go
@@ -460,6 +460,77 @@ func TestApplyEnvironmentDefaults_PerAttemptTimeoutConfigOverridesEnv(t *testing
 	}
 }
 
+func TestParseClientOptions_PerAttemptTimeoutExceedsTimeout(t *testing.T) {
+	tests := []struct {
+		name              string
+		timeout           string
+		perAttemptTimeout string
+		wantWarning       bool
+	}{
+		{
+			name:              "per_attempt_timeout greater than timeout warns",
+			timeout:           "30s",
+			perAttemptTimeout: "60s",
+			wantWarning:       true,
+		},
+		{
+			name:              "per_attempt_timeout equal to timeout warns",
+			timeout:           "30s",
+			perAttemptTimeout: "30s",
+			wantWarning:       true,
+		},
+		{
+			name:              "per_attempt_timeout less than timeout does not warn",
+			timeout:           "30s",
+			perAttemptTimeout: "5s",
+			wantWarning:       false,
+		},
+		{
+			name:              "per_attempt_timeout set but timeout not set does not warn",
+			timeout:           "",
+			perAttemptTimeout: "60s",
+			wantWarning:       false,
+		},
+		{
+			name:              "timeout set but per_attempt_timeout not set does not warn",
+			timeout:           "30s",
+			perAttemptTimeout: "",
+			wantWarning:       false,
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			model := UptimeKumaProviderModel{
+				Endpoint:          types.StringNull(),
+				Username:          types.StringNull(),
+				Password:          types.StringNull(),
+				Timeout:           types.StringNull(),
+				PerAttemptTimeout: types.StringNull(),
+				MaxRetries:        types.Int64Null(),
+			}
+
+			if tc.timeout != "" {
+				model.Timeout = types.StringValue(tc.timeout)
+			}
+
+			if tc.perAttemptTimeout != "" {
+				model.PerAttemptTimeout = types.StringValue(tc.perAttemptTimeout)
+			}
+
+			resp := &provider.ConfigureResponse{}
+			parseClientOptions(&model, resp)
+
+			hasWarning := len(resp.Diagnostics.Warnings()) > 0
+
+			if hasWarning != tc.wantWarning {
+				t.Errorf("wantWarning=%v but hasWarning=%v (warnings: %v)",
+					tc.wantWarning, hasWarning, resp.Diagnostics.Warnings())
+			}
+		})
+	}
+}
+
 func TestAccProviderInvalidTimeout(t *testing.T) {
 	resource.Test(t, resource.TestCase{
 		ProtoV6ProviderFactories: testAccProtoV6ProviderFactories,


### PR DESCRIPTION
The provider's `timeout` setting was previously interpreted as a per-attempt deadline, with the overall connection budget computed as `timeout * (max_retries + 1)`. With the default `max_retries` of 5, setting `timeout = "30s"` therefore allowed up to ~3 minutes of total connection time — which contradicted user expectations and could cause `terraform plan` to appear to hang for several minutes when the Uptime Kuma endpoint was unreachable.

This PR reworks the timeout semantics:

- `timeout` is now the overall connection budget across all retry attempts and backoff. The retry loop is bounded by a single deadline derived from `timeout`, and per-attempt connect timeouts are capped to the remaining budget.
- A new `per_attempt_timeout` provider attribute (and matching `UPTIMEKUMA_PER_ATTEMPT_TIMEOUT` environment variable) caps each individual connection attempt. The effective per-attempt timeout is the smaller of `per_attempt_timeout` and the remaining `timeout` budget.
- The default `max_retries` value is lowered from 5 to 3, so the default 30s budget is split across a small number of attempts without requiring a large total wait.

This matches the design suggested in the issue discussion (keep `timeout` for backward compatibility but redefine it as the global budget, lower the default `max_retries`, and add an explicit per-attempt knob).

Closes #265