### PR TITLE
fix: resolve indefinite hang against Uptime Kuma 2.3.x

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -3,7 +3,7 @@ module github.com/breml/terraform-provider-uptimekuma
 go 1.25.8
 
 require (
-	github.com/breml/go-uptime-kuma-client v0.3.2
+	github.com/breml/go-uptime-kuma-client v0.3.3
 	github.com/hashicorp/terraform-plugin-framework v1.19.0
 	github.com/hashicorp/terraform-plugin-go v0.31.0
 	github.com/hashicorp/terraform-plugin-log v0.10.0

--- a/go.sum
+++ b/go.sum
@@ -170,8 +170,8 @@ github.com/breml/errchkjson v0.4.1 h1:keFSS8D7A2T0haP9kzZTi7o26r7kE3vymjZNeNDRDw
 github.com/breml/errchkjson v0.4.1/go.mod h1:a23OvR6Qvcl7DG/Z4o0el6BRAjKnaReoPQFciAl9U3s=
 github.com/breml/githooks v0.0.0-20260328191633-541253a9d3bd h1:Y8xr806ar32BjMXH26TtNKI4gFvTf5oAgZqygoaaeF4=
 github.com/breml/githooks v0.0.0-20260328191633-541253a9d3bd/go.mod h1:wSedAMuNx+ige9zqCTwIJufpRAenWlIgM6zNZ9Npae4=
-github.com/breml/go-uptime-kuma-client v0.3.2 h1:4eyQap30N4ksew7wfp++NC8R6ubdrXh5kr4uluVWoy8=
-github.com/breml/go-uptime-kuma-client v0.3.2/go.mod h1:QNfjHHvo4E0rTngFkU0LbQ9iChdbIwcFBowVIt4PRPE=
+github.com/breml/go-uptime-kuma-client v0.3.3 h1:SUJiJkaCHdwgdmqDNRSzNTYSZ4eNJumd6Gb/7l9k/eE=
+github.com/breml/go-uptime-kuma-client v0.3.3/go.mod h1:QNfjHHvo4E0rTngFkU0LbQ9iChdbIwcFBowVIt4PRPE=
 github.com/breml/go.socket.io v0.0.0-20260415184737-53d789da8f28 h1:2kD1B5TfvBKGL4zal8WWkAUOkv1XMEcbUcJbe6Nue0Y=
 github.com/breml/go.socket.io v0.0.0-20260415184737-53d789da8f28/go.mod h1:H1EoWDJvqfV2WryM8F9og6ZkH7NsZDlHr0BRkKb58tY=
 github.com/breml/newline-after-block v0.0.0-20251225141726-84337171eef7 h1:ilIWXePccxYq7HvA/max1ZqS0kTkIB/sKzBPDneECts=

--- a/internal/provider/main_test.go
+++ b/internal/provider/main_test.go
@@ -55,7 +55,7 @@ func runTests(m *testing.M) (exitcode int) {
 		// pulls an image, creates a container based on it and runs it
 		container, err := pool.RunWithOptions(&dockertest.RunOptions{
 			Repository: "louislam/uptime-kuma",
-			Tag:        "2.2.0",
+			Tag:        "2.3.2",
 		}, func(config *docker.HostConfig) {
 			// set AutoRemove to true so that stopped container goes away by itself
 			config.AutoRemove = true


### PR DESCRIPTION
## Summary

Resolve [#323](https://github.com/breml/terraform-provider-uptimekuma/issues/323)
by bumping `github.com/breml/go-uptime-kuma-client` from `v0.3.2` to `v0.3.3`,
which contains the upstream fix for [breml/go-uptime-kuma-client#271](https://github.com/breml/go-uptime-kuma-client/issues/271).

Also bump the docker image tag used by acceptance tests in
[`internal/provider/main_test.go`](internal/provider/main_test.go) from `2.2.0`
to `2.3.2` so the test suite exercises the latest Uptime Kuma release and
catches future regressions of this kind.

## Root cause

In `go-uptime-kuma-client` v0.3.2, the final wait-for-ready loop in
`kuma.New()` only watched `ctx.Done()` and ignored the connect-timeout
context. The provider passes `context.Background()` to `kuma.New()`
(intentionally — the socket must outlive `Configure()`), so when Uptime
Kuma 2.3.x omitted a required ready event (e.g. `apiKeyList`), `New()`
blocked forever regardless of the provider's `timeout` and `max_retries`.

`v0.3.3` adds a `<-connectTimeoutDone` arm to the ready-wait `select`, so the
configured timeout now fires correctly.

## Verification

- `task fmt` — clean
- `task lint` — 0 issues
- `task testacc` — full acceptance suite passes against `louislam/uptime-kuma:2.3.2`

Closes #323
