### PR TITLE
fix(monitor): detect external monitor type drift in Read

### DIFF
--- a/internal/provider/resource_disappears_test.go
+++ b/internal/provider/resource_disappears_test.go
@@ -265,6 +265,8 @@ func testAccChangeMonitorTypeToHTTP(
 			Base: pingMonitor.Base,
 		}
 		httpMonitor.URL = "https://httpbin.org/status/200"
+		// Server requires accepted_statuscodes to be an array, not null.
+		httpMonitor.AcceptedStatusCodes = []string{"200-299"}
 
 		updateErr := kumaClient.UpdateMonitor(ctx, &httpMonitor)
 		if updateErr != nil {

--- a/internal/provider/resource_disappears_test.go
+++ b/internal/provider/resource_disappears_test.go
@@ -15,6 +15,7 @@ import (
 	"github.com/hashicorp/terraform-plugin-testing/terraform"
 
 	kuma "github.com/breml/go-uptime-kuma-client"
+	"github.com/breml/go-uptime-kuma-client/monitor"
 )
 
 // testAccOutOfBandClient returns the dedicated out-of-band kuma client for use
@@ -218,6 +219,92 @@ func TestAccTagResource_disappears(t *testing.T) {
 					PostRefresh: []plancheck.PlanCheck{
 						plancheck.ExpectResourceAction(
 							"uptimekuma_tag.test",
+							plancheck.ResourceActionCreate,
+						),
+					},
+				},
+			},
+		},
+	})
+}
+
+// testAccChangeMonitorTypeToHTTP changes a monitor's type to HTTP via the kuma
+// API, simulating an external type change outside of Terraform.
+func testAccChangeMonitorTypeToHTTP(
+	t *testing.T,
+	kumaClient *kuma.Client,
+	resourceAddr string,
+) resource.TestCheckFunc {
+	t.Helper()
+
+	return func(s *terraform.State) error {
+		rs, ok := s.RootModule().Resources[resourceAddr]
+		if !ok {
+			return fmt.Errorf("resource %s not found in state", resourceAddr)
+		}
+
+		id, err := strconv.ParseInt(rs.Primary.Attributes["id"], 10, 64)
+		if err != nil {
+			return fmt.Errorf("failed to parse monitor id: %w", err)
+		}
+
+		ctx, cancel := context.WithTimeout(t.Context(), 10*time.Second)
+		defer cancel()
+
+		// Get current monitor to copy base fields (ID, Name, Interval, etc.)
+		var pingMonitor monitor.Ping
+		getErr := kumaClient.GetMonitorAs(ctx, id, &pingMonitor)
+		if getErr != nil {
+			return fmt.Errorf("failed to get monitor: %w", getErr)
+		}
+
+		// Build an HTTP monitor with the same base fields but a different type.
+		// HTTP.MarshalJSON hardcodes type="http", so UpdateMonitor changes the
+		// server-side type regardless of the base's internalType.
+		httpMonitor := monitor.HTTP{
+			Base: pingMonitor.Base,
+		}
+		httpMonitor.URL = "https://httpbin.org/status/200"
+
+		updateErr := kumaClient.UpdateMonitor(ctx, &httpMonitor)
+		if updateErr != nil {
+			return fmt.Errorf("failed to change monitor type to http: %w", updateErr)
+		}
+
+		return nil
+	}
+}
+
+// TestAccMonitorPingResource_typeDrift verifies that when a ping monitor's type
+// is changed externally in Uptime Kuma, the provider detects the drift and
+// removes the resource from state, triggering a re-create on the next plan.
+func TestAccMonitorPingResource_typeDrift(t *testing.T) {
+	name := acctest.RandomWithPrefix("TestPingTypeDrift")
+	kumaClient := testAccOutOfBandClient(t)
+
+	config := providerConfig() + fmt.Sprintf(`
+resource "uptimekuma_monitor_ping" "test" {
+  name     = %[1]q
+  hostname = "8.8.8.8"
+}
+`, name)
+
+	resource.Test(t, resource.TestCase{
+		PreCheck:                 func() { testAccPreCheck(t) },
+		ProtoV6ProviderFactories: testAccProtoV6ProviderFactories,
+		Steps: []resource.TestStep{
+			{
+				Config:             config,
+				Check:              testAccChangeMonitorTypeToHTTP(t, kumaClient, "uptimekuma_monitor_ping.test"),
+				ExpectNonEmptyPlan: true,
+			},
+			{
+				RefreshState:       true,
+				ExpectNonEmptyPlan: true,
+				RefreshPlanChecks: resource.RefreshPlanChecks{
+					PostRefresh: []plancheck.PlanCheck{
+						plancheck.ExpectResourceAction(
+							"uptimekuma_monitor_ping.test",
 							plancheck.ResourceActionCreate,
 						),
 					},

--- a/internal/provider/resource_monitor_dns.go
+++ b/internal/provider/resource_monitor_dns.go
@@ -196,6 +196,11 @@ func (r *MonitorDNSResource) Read(ctx context.Context, req resource.ReadRequest,
 		return
 	}
 
+	if dnsMonitor.Base.Type() != dnsMonitor.Type() {
+		resp.State.RemoveResource(ctx)
+		return
+	}
+
 	data.Name = types.StringValue(dnsMonitor.Name)
 	if dnsMonitor.Description != nil {
 		data.Description = types.StringValue(*dnsMonitor.Description)

--- a/internal/provider/resource_monitor_dns.go
+++ b/internal/provider/resource_monitor_dns.go
@@ -14,6 +14,7 @@ import (
 	"github.com/hashicorp/terraform-plugin-framework/resource/schema/stringdefault"
 	"github.com/hashicorp/terraform-plugin-framework/schema/validator"
 	"github.com/hashicorp/terraform-plugin-framework/types"
+	"github.com/hashicorp/terraform-plugin-log/tflog"
 
 	kuma "github.com/breml/go-uptime-kuma-client"
 	"github.com/breml/go-uptime-kuma-client/monitor"
@@ -196,7 +197,12 @@ func (r *MonitorDNSResource) Read(ctx context.Context, req resource.ReadRequest,
 		return
 	}
 
-	if dnsMonitor.Base.Type() != dnsMonitor.Type() {
+	if actual := dnsMonitor.Base.Type(); actual != "" && actual != dnsMonitor.Type() {
+		tflog.Warn(ctx, "monitor type changed externally, removing from state", map[string]any{
+			"id":            data.ID.ValueInt64(),
+			"expected_type": dnsMonitor.Type(),
+			"actual_type":   actual,
+		})
 		resp.State.RemoveResource(ctx)
 		return
 	}

--- a/internal/provider/resource_monitor_docker.go
+++ b/internal/provider/resource_monitor_docker.go
@@ -205,6 +205,11 @@ func (r *MonitorDockerResource) Read(ctx context.Context, req resource.ReadReque
 		return
 	}
 
+	if dockerMonitor.Base.Type() != dockerMonitor.Type() {
+		resp.State.RemoveResource(ctx)
+		return
+	}
+
 	populateDockerMonitorBaseFields(&dockerMonitor, &data)
 	populateOptionalFieldsForDocker(ctx, &dockerMonitor, &data, &resp.Diagnostics)
 

--- a/internal/provider/resource_monitor_docker.go
+++ b/internal/provider/resource_monitor_docker.go
@@ -10,6 +10,7 @@ import (
 	"github.com/hashicorp/terraform-plugin-framework/resource"
 	"github.com/hashicorp/terraform-plugin-framework/resource/schema"
 	"github.com/hashicorp/terraform-plugin-framework/types"
+	"github.com/hashicorp/terraform-plugin-log/tflog"
 
 	kuma "github.com/breml/go-uptime-kuma-client"
 	"github.com/breml/go-uptime-kuma-client/monitor"
@@ -205,7 +206,12 @@ func (r *MonitorDockerResource) Read(ctx context.Context, req resource.ReadReque
 		return
 	}
 
-	if dockerMonitor.Base.Type() != dockerMonitor.Type() {
+	if actual := dockerMonitor.Base.Type(); actual != "" && actual != dockerMonitor.Type() {
+		tflog.Warn(ctx, "monitor type changed externally, removing from state", map[string]any{
+			"id":            data.ID.ValueInt64(),
+			"expected_type": dockerMonitor.Type(),
+			"actual_type":   actual,
+		})
 		resp.State.RemoveResource(ctx)
 		return
 	}

--- a/internal/provider/resource_monitor_gamedig.go
+++ b/internal/provider/resource_monitor_gamedig.go
@@ -170,6 +170,11 @@ func (r *MonitorGameDigResource) Read(ctx context.Context, req resource.ReadRequ
 		return
 	}
 
+	if gameDigMonitor.Base.Type() != gameDigMonitor.Type() {
+		resp.State.RemoveResource(ctx)
+		return
+	}
+
 	populateGameDigModel(&gameDigMonitor, &data)
 	populateGameDigOptionalFields(ctx, &gameDigMonitor, &data, &resp.Diagnostics)
 	if resp.Diagnostics.HasError() {

--- a/internal/provider/resource_monitor_gamedig.go
+++ b/internal/provider/resource_monitor_gamedig.go
@@ -14,6 +14,7 @@ import (
 	"github.com/hashicorp/terraform-plugin-framework/resource/schema/booldefault"
 	"github.com/hashicorp/terraform-plugin-framework/schema/validator"
 	"github.com/hashicorp/terraform-plugin-framework/types"
+	"github.com/hashicorp/terraform-plugin-log/tflog"
 
 	kuma "github.com/breml/go-uptime-kuma-client"
 	"github.com/breml/go-uptime-kuma-client/monitor"
@@ -170,7 +171,12 @@ func (r *MonitorGameDigResource) Read(ctx context.Context, req resource.ReadRequ
 		return
 	}
 
-	if gameDigMonitor.Base.Type() != gameDigMonitor.Type() {
+	if actual := gameDigMonitor.Base.Type(); actual != "" && actual != gameDigMonitor.Type() {
+		tflog.Warn(ctx, "monitor type changed externally, removing from state", map[string]any{
+			"id":            data.ID.ValueInt64(),
+			"expected_type": gameDigMonitor.Type(),
+			"actual_type":   actual,
+		})
 		resp.State.RemoveResource(ctx)
 		return
 	}

--- a/internal/provider/resource_monitor_group.go
+++ b/internal/provider/resource_monitor_group.go
@@ -9,6 +9,7 @@ import (
 	"github.com/hashicorp/terraform-plugin-framework/resource"
 	"github.com/hashicorp/terraform-plugin-framework/resource/schema"
 	"github.com/hashicorp/terraform-plugin-framework/types"
+	"github.com/hashicorp/terraform-plugin-log/tflog"
 
 	kuma "github.com/breml/go-uptime-kuma-client"
 	"github.com/breml/go-uptime-kuma-client/monitor"
@@ -151,7 +152,12 @@ func (r *MonitorGroupResource) Read(ctx context.Context, req resource.ReadReques
 		return
 	}
 
-	if groupMonitor.Base.Type() != groupMonitor.Type() {
+	if actual := groupMonitor.Base.Type(); actual != "" && actual != groupMonitor.Type() {
+		tflog.Warn(ctx, "monitor type changed externally, removing from state", map[string]any{
+			"id":            data.ID.ValueInt64(),
+			"expected_type": groupMonitor.Type(),
+			"actual_type":   actual,
+		})
 		resp.State.RemoveResource(ctx)
 		return
 	}

--- a/internal/provider/resource_monitor_group.go
+++ b/internal/provider/resource_monitor_group.go
@@ -151,6 +151,11 @@ func (r *MonitorGroupResource) Read(ctx context.Context, req resource.ReadReques
 		return
 	}
 
+	if groupMonitor.Base.Type() != groupMonitor.Type() {
+		resp.State.RemoveResource(ctx)
+		return
+	}
+
 	data.Name = types.StringValue(groupMonitor.Name)
 	if groupMonitor.Description != nil {
 		data.Description = types.StringValue(*groupMonitor.Description)

--- a/internal/provider/resource_monitor_grpc_keyword.go
+++ b/internal/provider/resource_monitor_grpc_keyword.go
@@ -13,6 +13,7 @@ import (
 	"github.com/hashicorp/terraform-plugin-framework/resource/schema/booldefault"
 	"github.com/hashicorp/terraform-plugin-framework/schema/validator"
 	"github.com/hashicorp/terraform-plugin-framework/types"
+	"github.com/hashicorp/terraform-plugin-log/tflog"
 
 	kuma "github.com/breml/go-uptime-kuma-client"
 	"github.com/breml/go-uptime-kuma-client/monitor"
@@ -253,7 +254,12 @@ func (r *MonitorGrpcKeywordResource) Read(ctx context.Context, req resource.Read
 		return
 	}
 
-	if grpcKeywordMonitor.Base.Type() != grpcKeywordMonitor.Type() {
+	if actual := grpcKeywordMonitor.Base.Type(); actual != "" && actual != grpcKeywordMonitor.Type() {
+		tflog.Warn(ctx, "monitor type changed externally, removing from state", map[string]any{
+			"id":            data.ID.ValueInt64(),
+			"expected_type": grpcKeywordMonitor.Type(),
+			"actual_type":   actual,
+		})
 		resp.State.RemoveResource(ctx)
 		return
 	}

--- a/internal/provider/resource_monitor_grpc_keyword.go
+++ b/internal/provider/resource_monitor_grpc_keyword.go
@@ -253,6 +253,11 @@ func (r *MonitorGrpcKeywordResource) Read(ctx context.Context, req resource.Read
 		return
 	}
 
+	if grpcKeywordMonitor.Base.Type() != grpcKeywordMonitor.Type() {
+		resp.State.RemoveResource(ctx)
+		return
+	}
+
 	r.populateModelFromMonitor(ctx, &data, &grpcKeywordMonitor, &resp.Diagnostics)
 	if resp.Diagnostics.HasError() {
 		return

--- a/internal/provider/resource_monitor_http.go
+++ b/internal/provider/resource_monitor_http.go
@@ -10,6 +10,7 @@ import (
 	"github.com/hashicorp/terraform-plugin-framework/resource"
 	"github.com/hashicorp/terraform-plugin-framework/resource/schema"
 	"github.com/hashicorp/terraform-plugin-framework/types"
+	"github.com/hashicorp/terraform-plugin-log/tflog"
 
 	kuma "github.com/breml/go-uptime-kuma-client"
 	"github.com/breml/go-uptime-kuma-client/monitor"
@@ -299,7 +300,12 @@ func (r *MonitorHTTPResource) Read(ctx context.Context, req resource.ReadRequest
 		return
 	}
 
-	if httpMonitor.Base.Type() != httpMonitor.Type() {
+	if actual := httpMonitor.Base.Type(); actual != "" && actual != httpMonitor.Type() {
+		tflog.Warn(ctx, "monitor type changed externally, removing from state", map[string]any{
+			"id":            data.ID.ValueInt64(),
+			"expected_type": httpMonitor.Type(),
+			"actual_type":   actual,
+		})
 		resp.State.RemoveResource(ctx)
 		return
 	}

--- a/internal/provider/resource_monitor_http.go
+++ b/internal/provider/resource_monitor_http.go
@@ -299,6 +299,11 @@ func (r *MonitorHTTPResource) Read(ctx context.Context, req resource.ReadRequest
 		return
 	}
 
+	if httpMonitor.Base.Type() != httpMonitor.Type() {
+		resp.State.RemoveResource(ctx)
+		return
+	}
+
 	populateHTTPMonitorBaseFieldsForHTTP(&httpMonitor, &data)
 	populateOptionalFieldsForHTTP(ctx, &httpMonitor, &data, &resp.Diagnostics)
 

--- a/internal/provider/resource_monitor_http_json_query.go
+++ b/internal/provider/resource_monitor_http_json_query.go
@@ -338,6 +338,11 @@ func (r *MonitorHTTPJSONQueryResource) Read(
 		return
 	}
 
+	if httpJSONQueryMonitor.Base.Type() != httpJSONQueryMonitor.Type() {
+		resp.State.RemoveResource(ctx)
+		return
+	}
+
 	var httpMonitor monitor.HTTP
 	httpMonitor.Base = httpJSONQueryMonitor.Base
 	httpMonitor.HTTPDetails = httpJSONQueryMonitor.HTTPDetails

--- a/internal/provider/resource_monitor_http_json_query.go
+++ b/internal/provider/resource_monitor_http_json_query.go
@@ -13,6 +13,7 @@ import (
 	"github.com/hashicorp/terraform-plugin-framework/resource/schema/stringdefault"
 	"github.com/hashicorp/terraform-plugin-framework/schema/validator"
 	"github.com/hashicorp/terraform-plugin-framework/types"
+	"github.com/hashicorp/terraform-plugin-log/tflog"
 
 	kuma "github.com/breml/go-uptime-kuma-client"
 	"github.com/breml/go-uptime-kuma-client/monitor"
@@ -338,7 +339,12 @@ func (r *MonitorHTTPJSONQueryResource) Read(
 		return
 	}
 
-	if httpJSONQueryMonitor.Base.Type() != httpJSONQueryMonitor.Type() {
+	if actual := httpJSONQueryMonitor.Base.Type(); actual != "" && actual != httpJSONQueryMonitor.Type() {
+		tflog.Warn(ctx, "monitor type changed externally, removing from state", map[string]any{
+			"id":            data.ID.ValueInt64(),
+			"expected_type": httpJSONQueryMonitor.Type(),
+			"actual_type":   actual,
+		})
 		resp.State.RemoveResource(ctx)
 		return
 	}

--- a/internal/provider/resource_monitor_http_keyword.go
+++ b/internal/provider/resource_monitor_http_keyword.go
@@ -13,6 +13,7 @@ import (
 	"github.com/hashicorp/terraform-plugin-framework/resource/schema/booldefault"
 	"github.com/hashicorp/terraform-plugin-framework/schema/validator"
 	"github.com/hashicorp/terraform-plugin-framework/types"
+	"github.com/hashicorp/terraform-plugin-log/tflog"
 
 	kuma "github.com/breml/go-uptime-kuma-client"
 	"github.com/breml/go-uptime-kuma-client/monitor"
@@ -324,7 +325,12 @@ func (r *MonitorHTTPKeywordResource) Read(ctx context.Context, req resource.Read
 		return
 	}
 
-	if httpKeywordMonitor.Base.Type() != httpKeywordMonitor.Type() {
+	if actual := httpKeywordMonitor.Base.Type(); actual != "" && actual != httpKeywordMonitor.Type() {
+		tflog.Warn(ctx, "monitor type changed externally, removing from state", map[string]any{
+			"id":            data.ID.ValueInt64(),
+			"expected_type": httpKeywordMonitor.Type(),
+			"actual_type":   actual,
+		})
 		resp.State.RemoveResource(ctx)
 		return
 	}

--- a/internal/provider/resource_monitor_http_keyword.go
+++ b/internal/provider/resource_monitor_http_keyword.go
@@ -324,6 +324,11 @@ func (r *MonitorHTTPKeywordResource) Read(ctx context.Context, req resource.Read
 		return
 	}
 
+	if httpKeywordMonitor.Base.Type() != httpKeywordMonitor.Type() {
+		resp.State.RemoveResource(ctx)
+		return
+	}
+
 	var httpMonitor monitor.HTTP
 	httpMonitor.Base = httpKeywordMonitor.Base
 	httpMonitor.HTTPDetails = httpKeywordMonitor.HTTPDetails

--- a/internal/provider/resource_monitor_kafka_producer.go
+++ b/internal/provider/resource_monitor_kafka_producer.go
@@ -12,6 +12,7 @@ import (
 	"github.com/hashicorp/terraform-plugin-framework/resource/schema"
 	"github.com/hashicorp/terraform-plugin-framework/resource/schema/booldefault"
 	"github.com/hashicorp/terraform-plugin-framework/types"
+	"github.com/hashicorp/terraform-plugin-log/tflog"
 
 	kuma "github.com/breml/go-uptime-kuma-client"
 	"github.com/breml/go-uptime-kuma-client/monitor"
@@ -305,7 +306,12 @@ func (r *MonitorKafkaProducerResource) Read(
 		return
 	}
 
-	if kafkaMonitor.Base.Type() != kafkaMonitor.Type() {
+	if actual := kafkaMonitor.Base.Type(); actual != "" && actual != kafkaMonitor.Type() {
+		tflog.Warn(ctx, "monitor type changed externally, removing from state", map[string]any{
+			"id":            data.ID.ValueInt64(),
+			"expected_type": kafkaMonitor.Type(),
+			"actual_type":   actual,
+		})
 		resp.State.RemoveResource(ctx)
 		return
 	}

--- a/internal/provider/resource_monitor_kafka_producer.go
+++ b/internal/provider/resource_monitor_kafka_producer.go
@@ -305,6 +305,11 @@ func (r *MonitorKafkaProducerResource) Read(
 		return
 	}
 
+	if kafkaMonitor.Base.Type() != kafkaMonitor.Type() {
+		resp.State.RemoveResource(ctx)
+		return
+	}
+
 	populateKafkaProducerMonitorBaseFields(ctx, &kafkaMonitor, &data, &resp.Diagnostics)
 	populateOptionalFieldsForKafkaProducer(ctx, &kafkaMonitor, &data, &resp.Diagnostics)
 

--- a/internal/provider/resource_monitor_mongodb.go
+++ b/internal/provider/resource_monitor_mongodb.go
@@ -10,6 +10,7 @@ import (
 	"github.com/hashicorp/terraform-plugin-framework/resource/schema"
 	"github.com/hashicorp/terraform-plugin-framework/resource/schema/stringdefault"
 	"github.com/hashicorp/terraform-plugin-framework/types"
+	"github.com/hashicorp/terraform-plugin-log/tflog"
 
 	kuma "github.com/breml/go-uptime-kuma-client"
 	"github.com/breml/go-uptime-kuma-client/monitor"
@@ -194,7 +195,12 @@ func (r *MonitorMongoDBResource) Read(
 		return
 	}
 
-	if mongoDBMonitor.Base.Type() != mongoDBMonitor.Type() {
+	if actual := mongoDBMonitor.Base.Type(); actual != "" && actual != mongoDBMonitor.Type() {
+		tflog.Warn(ctx, "monitor type changed externally, removing from state", map[string]any{
+			"id":            data.ID.ValueInt64(),
+			"expected_type": mongoDBMonitor.Type(),
+			"actual_type":   actual,
+		})
 		resp.State.RemoveResource(ctx)
 		return
 	}

--- a/internal/provider/resource_monitor_mongodb.go
+++ b/internal/provider/resource_monitor_mongodb.go
@@ -194,6 +194,11 @@ func (r *MonitorMongoDBResource) Read(
 		return
 	}
 
+	if mongoDBMonitor.Base.Type() != mongoDBMonitor.Type() {
+		resp.State.RemoveResource(ctx)
+		return
+	}
+
 	data.Name = types.StringValue(mongoDBMonitor.Name)
 	if mongoDBMonitor.Description != nil {
 		data.Description = types.StringValue(*mongoDBMonitor.Description)

--- a/internal/provider/resource_monitor_mqtt.go
+++ b/internal/provider/resource_monitor_mqtt.go
@@ -326,6 +326,11 @@ func (r *MonitorMQTTResource) Read(ctx context.Context, req resource.ReadRequest
 		return
 	}
 
+	if mqttMonitor.Base.Type() != mqttMonitor.Type() {
+		resp.State.RemoveResource(ctx)
+		return
+	}
+
 	populateMQTTMonitorBaseFieldsForMQTT(&mqttMonitor, &data)
 	populateOptionalFieldsForMQTT(ctx, &mqttMonitor, &data, &resp.Diagnostics)
 

--- a/internal/provider/resource_monitor_mqtt.go
+++ b/internal/provider/resource_monitor_mqtt.go
@@ -14,6 +14,7 @@ import (
 	"github.com/hashicorp/terraform-plugin-framework/resource/schema/stringdefault"
 	"github.com/hashicorp/terraform-plugin-framework/schema/validator"
 	"github.com/hashicorp/terraform-plugin-framework/types"
+	"github.com/hashicorp/terraform-plugin-log/tflog"
 
 	kuma "github.com/breml/go-uptime-kuma-client"
 	"github.com/breml/go-uptime-kuma-client/monitor"
@@ -326,7 +327,12 @@ func (r *MonitorMQTTResource) Read(ctx context.Context, req resource.ReadRequest
 		return
 	}
 
-	if mqttMonitor.Base.Type() != mqttMonitor.Type() {
+	if actual := mqttMonitor.Base.Type(); actual != "" && actual != mqttMonitor.Type() {
+		tflog.Warn(ctx, "monitor type changed externally, removing from state", map[string]any{
+			"id":            data.ID.ValueInt64(),
+			"expected_type": mqttMonitor.Type(),
+			"actual_type":   actual,
+		})
 		resp.State.RemoveResource(ctx)
 		return
 	}

--- a/internal/provider/resource_monitor_mysql.go
+++ b/internal/provider/resource_monitor_mysql.go
@@ -179,6 +179,11 @@ func (r *MonitorMySQLResource) Read(ctx context.Context, req resource.ReadReques
 		return
 	}
 
+	if mysqlMonitor.Base.Type() != mysqlMonitor.Type() {
+		resp.State.RemoveResource(ctx)
+		return
+	}
+
 	data.Name = types.StringValue(mysqlMonitor.Name)
 	if mysqlMonitor.Description != nil {
 		data.Description = types.StringValue(*mysqlMonitor.Description)

--- a/internal/provider/resource_monitor_mysql.go
+++ b/internal/provider/resource_monitor_mysql.go
@@ -10,6 +10,7 @@ import (
 	"github.com/hashicorp/terraform-plugin-framework/resource/schema"
 	"github.com/hashicorp/terraform-plugin-framework/resource/schema/stringdefault"
 	"github.com/hashicorp/terraform-plugin-framework/types"
+	"github.com/hashicorp/terraform-plugin-log/tflog"
 
 	kuma "github.com/breml/go-uptime-kuma-client"
 	"github.com/breml/go-uptime-kuma-client/monitor"
@@ -179,7 +180,12 @@ func (r *MonitorMySQLResource) Read(ctx context.Context, req resource.ReadReques
 		return
 	}
 
-	if mysqlMonitor.Base.Type() != mysqlMonitor.Type() {
+	if actual := mysqlMonitor.Base.Type(); actual != "" && actual != mysqlMonitor.Type() {
+		tflog.Warn(ctx, "monitor type changed externally, removing from state", map[string]any{
+			"id":            data.ID.ValueInt64(),
+			"expected_type": mysqlMonitor.Type(),
+			"actual_type":   actual,
+		})
 		resp.State.RemoveResource(ctx)
 		return
 	}

--- a/internal/provider/resource_monitor_ping.go
+++ b/internal/provider/resource_monitor_ping.go
@@ -12,6 +12,7 @@ import (
 	"github.com/hashicorp/terraform-plugin-framework/resource/schema/int64default"
 	"github.com/hashicorp/terraform-plugin-framework/schema/validator"
 	"github.com/hashicorp/terraform-plugin-framework/types"
+	"github.com/hashicorp/terraform-plugin-log/tflog"
 
 	kuma "github.com/breml/go-uptime-kuma-client"
 	"github.com/breml/go-uptime-kuma-client/monitor"
@@ -190,7 +191,12 @@ func (r *MonitorPingResource) Read(ctx context.Context, req resource.ReadRequest
 		return
 	}
 
-	if pingMonitor.Base.Type() != pingMonitor.Type() {
+	if actual := pingMonitor.Base.Type(); actual != "" && actual != pingMonitor.Type() {
+		tflog.Warn(ctx, "monitor type changed externally, removing from state", map[string]any{
+			"id":            data.ID.ValueInt64(),
+			"expected_type": pingMonitor.Type(),
+			"actual_type":   actual,
+		})
 		resp.State.RemoveResource(ctx)
 		return
 	}

--- a/internal/provider/resource_monitor_ping.go
+++ b/internal/provider/resource_monitor_ping.go
@@ -190,6 +190,11 @@ func (r *MonitorPingResource) Read(ctx context.Context, req resource.ReadRequest
 		return
 	}
 
+	if pingMonitor.Base.Type() != pingMonitor.Type() {
+		resp.State.RemoveResource(ctx)
+		return
+	}
+
 	data.Name = types.StringValue(pingMonitor.Name)
 	if pingMonitor.Description != nil {
 		data.Description = types.StringValue(*pingMonitor.Description)

--- a/internal/provider/resource_monitor_postgres.go
+++ b/internal/provider/resource_monitor_postgres.go
@@ -179,6 +179,11 @@ func (r *MonitorPostgresResource) Read(ctx context.Context, req resource.ReadReq
 		return
 	}
 
+	if postgresMonitor.Base.Type() != postgresMonitor.Type() {
+		resp.State.RemoveResource(ctx)
+		return
+	}
+
 	data.Name = types.StringValue(postgresMonitor.Name)
 	if postgresMonitor.Description != nil {
 		data.Description = types.StringValue(*postgresMonitor.Description)

--- a/internal/provider/resource_monitor_postgres.go
+++ b/internal/provider/resource_monitor_postgres.go
@@ -10,6 +10,7 @@ import (
 	"github.com/hashicorp/terraform-plugin-framework/resource/schema"
 	"github.com/hashicorp/terraform-plugin-framework/resource/schema/stringdefault"
 	"github.com/hashicorp/terraform-plugin-framework/types"
+	"github.com/hashicorp/terraform-plugin-log/tflog"
 
 	kuma "github.com/breml/go-uptime-kuma-client"
 	"github.com/breml/go-uptime-kuma-client/monitor"
@@ -179,7 +180,12 @@ func (r *MonitorPostgresResource) Read(ctx context.Context, req resource.ReadReq
 		return
 	}
 
-	if postgresMonitor.Base.Type() != postgresMonitor.Type() {
+	if actual := postgresMonitor.Base.Type(); actual != "" && actual != postgresMonitor.Type() {
+		tflog.Warn(ctx, "monitor type changed externally, removing from state", map[string]any{
+			"id":            data.ID.ValueInt64(),
+			"expected_type": postgresMonitor.Type(),
+			"actual_type":   actual,
+		})
 		resp.State.RemoveResource(ctx)
 		return
 	}

--- a/internal/provider/resource_monitor_push.go
+++ b/internal/provider/resource_monitor_push.go
@@ -13,6 +13,7 @@ import (
 	"github.com/hashicorp/terraform-plugin-framework/resource/schema/planmodifier"
 	"github.com/hashicorp/terraform-plugin-framework/resource/schema/stringplanmodifier"
 	"github.com/hashicorp/terraform-plugin-framework/types"
+	"github.com/hashicorp/terraform-plugin-log/tflog"
 
 	kuma "github.com/breml/go-uptime-kuma-client"
 	"github.com/breml/go-uptime-kuma-client/monitor"
@@ -216,7 +217,12 @@ func (r *MonitorPushResource) Read(ctx context.Context, req resource.ReadRequest
 		return
 	}
 
-	if pushMonitor.Base.Type() != pushMonitor.Type() {
+	if actual := pushMonitor.Base.Type(); actual != "" && actual != pushMonitor.Type() {
+		tflog.Warn(ctx, "monitor type changed externally, removing from state", map[string]any{
+			"id":            data.ID.ValueInt64(),
+			"expected_type": pushMonitor.Type(),
+			"actual_type":   actual,
+		})
 		resp.State.RemoveResource(ctx)
 		return
 	}

--- a/internal/provider/resource_monitor_push.go
+++ b/internal/provider/resource_monitor_push.go
@@ -216,6 +216,11 @@ func (r *MonitorPushResource) Read(ctx context.Context, req resource.ReadRequest
 		return
 	}
 
+	if pushMonitor.Base.Type() != pushMonitor.Type() {
+		resp.State.RemoveResource(ctx)
+		return
+	}
+
 	data.Name = types.StringValue(pushMonitor.Name)
 	if pushMonitor.Description != nil {
 		data.Description = types.StringValue(*pushMonitor.Description)

--- a/internal/provider/resource_monitor_rabbitmq.go
+++ b/internal/provider/resource_monitor_rabbitmq.go
@@ -200,6 +200,11 @@ func (r *MonitorRabbitMQResource) Read(
 		return
 	}
 
+	if rabbitMQMonitor.Base.Type() != rabbitMQMonitor.Type() {
+		resp.State.RemoveResource(ctx)
+		return
+	}
+
 	data.Name = types.StringValue(rabbitMQMonitor.Name)
 	if rabbitMQMonitor.Description != nil {
 		data.Description = types.StringValue(*rabbitMQMonitor.Description)

--- a/internal/provider/resource_monitor_rabbitmq.go
+++ b/internal/provider/resource_monitor_rabbitmq.go
@@ -12,6 +12,7 @@ import (
 	"github.com/hashicorp/terraform-plugin-framework/resource/schema/int64default"
 	"github.com/hashicorp/terraform-plugin-framework/schema/validator"
 	"github.com/hashicorp/terraform-plugin-framework/types"
+	"github.com/hashicorp/terraform-plugin-log/tflog"
 
 	kuma "github.com/breml/go-uptime-kuma-client"
 	"github.com/breml/go-uptime-kuma-client/monitor"
@@ -200,7 +201,12 @@ func (r *MonitorRabbitMQResource) Read(
 		return
 	}
 
-	if rabbitMQMonitor.Base.Type() != rabbitMQMonitor.Type() {
+	if actual := rabbitMQMonitor.Base.Type(); actual != "" && actual != rabbitMQMonitor.Type() {
+		tflog.Warn(ctx, "monitor type changed externally, removing from state", map[string]any{
+			"id":            data.ID.ValueInt64(),
+			"expected_type": rabbitMQMonitor.Type(),
+			"actual_type":   actual,
+		})
 		resp.State.RemoveResource(ctx)
 		return
 	}

--- a/internal/provider/resource_monitor_radius.go
+++ b/internal/provider/resource_monitor_radius.go
@@ -289,6 +289,11 @@ func (r *MonitorRadiusResource) Read(ctx context.Context, req resource.ReadReque
 		return
 	}
 
+	if radiusMonitor.Base.Type() != radiusMonitor.Type() {
+		resp.State.RemoveResource(ctx)
+		return
+	}
+
 	populateRadiusMonitorBaseFields(&radiusMonitor, &data)
 	populateOptionalFieldsForRadius(ctx, &radiusMonitor, &data, &resp.Diagnostics)
 

--- a/internal/provider/resource_monitor_radius.go
+++ b/internal/provider/resource_monitor_radius.go
@@ -13,6 +13,7 @@ import (
 	"github.com/hashicorp/terraform-plugin-framework/resource/schema/int64default"
 	"github.com/hashicorp/terraform-plugin-framework/schema/validator"
 	"github.com/hashicorp/terraform-plugin-framework/types"
+	"github.com/hashicorp/terraform-plugin-log/tflog"
 
 	kuma "github.com/breml/go-uptime-kuma-client"
 	"github.com/breml/go-uptime-kuma-client/monitor"
@@ -289,7 +290,12 @@ func (r *MonitorRadiusResource) Read(ctx context.Context, req resource.ReadReque
 		return
 	}
 
-	if radiusMonitor.Base.Type() != radiusMonitor.Type() {
+	if actual := radiusMonitor.Base.Type(); actual != "" && actual != radiusMonitor.Type() {
+		tflog.Warn(ctx, "monitor type changed externally, removing from state", map[string]any{
+			"id":            data.ID.ValueInt64(),
+			"expected_type": radiusMonitor.Type(),
+			"actual_type":   actual,
+		})
 		resp.State.RemoveResource(ctx)
 		return
 	}

--- a/internal/provider/resource_monitor_real_browser.go
+++ b/internal/provider/resource_monitor_real_browser.go
@@ -18,6 +18,7 @@ import (
 	"github.com/hashicorp/terraform-plugin-framework/resource/schema/planmodifier"
 	"github.com/hashicorp/terraform-plugin-framework/schema/validator"
 	"github.com/hashicorp/terraform-plugin-framework/types"
+	"github.com/hashicorp/terraform-plugin-log/tflog"
 
 	kuma "github.com/breml/go-uptime-kuma-client"
 	"github.com/breml/go-uptime-kuma-client/monitor"
@@ -332,7 +333,12 @@ func (r *MonitorRealBrowserResource) Read(ctx context.Context, req resource.Read
 		return
 	}
 
-	if realBrowserMonitor.Base.Type() != realBrowserMonitor.Type() {
+	if actual := realBrowserMonitor.Base.Type(); actual != "" && actual != realBrowserMonitor.Type() {
+		tflog.Warn(ctx, "monitor type changed externally, removing from state", map[string]any{
+			"id":            data.ID.ValueInt64(),
+			"expected_type": realBrowserMonitor.Type(),
+			"actual_type":   actual,
+		})
 		resp.State.RemoveResource(ctx)
 		return
 	}

--- a/internal/provider/resource_monitor_real_browser.go
+++ b/internal/provider/resource_monitor_real_browser.go
@@ -332,6 +332,11 @@ func (r *MonitorRealBrowserResource) Read(ctx context.Context, req resource.Read
 		return
 	}
 
+	if realBrowserMonitor.Base.Type() != realBrowserMonitor.Type() {
+		resp.State.RemoveResource(ctx)
+		return
+	}
+
 	populateRealBrowserMonitorBaseFields(&realBrowserMonitor, &data)
 	populateOptionalFieldsForRealBrowser(ctx, &realBrowserMonitor, &data, &resp.Diagnostics)
 

--- a/internal/provider/resource_monitor_redis.go
+++ b/internal/provider/resource_monitor_redis.go
@@ -171,6 +171,11 @@ func (r *MonitorRedisResource) Read(ctx context.Context, req resource.ReadReques
 		return
 	}
 
+	if redisMonitor.Base.Type() != redisMonitor.Type() {
+		resp.State.RemoveResource(ctx)
+		return
+	}
+
 	data.Name = types.StringValue(redisMonitor.Name)
 	if redisMonitor.Description != nil {
 		data.Description = types.StringValue(*redisMonitor.Description)

--- a/internal/provider/resource_monitor_redis.go
+++ b/internal/provider/resource_monitor_redis.go
@@ -10,6 +10,7 @@ import (
 	"github.com/hashicorp/terraform-plugin-framework/resource/schema"
 	"github.com/hashicorp/terraform-plugin-framework/resource/schema/booldefault"
 	"github.com/hashicorp/terraform-plugin-framework/types"
+	"github.com/hashicorp/terraform-plugin-log/tflog"
 
 	kuma "github.com/breml/go-uptime-kuma-client"
 	"github.com/breml/go-uptime-kuma-client/monitor"
@@ -171,7 +172,12 @@ func (r *MonitorRedisResource) Read(ctx context.Context, req resource.ReadReques
 		return
 	}
 
-	if redisMonitor.Base.Type() != redisMonitor.Type() {
+	if actual := redisMonitor.Base.Type(); actual != "" && actual != redisMonitor.Type() {
+		tflog.Warn(ctx, "monitor type changed externally, removing from state", map[string]any{
+			"id":            data.ID.ValueInt64(),
+			"expected_type": redisMonitor.Type(),
+			"actual_type":   actual,
+		})
 		resp.State.RemoveResource(ctx)
 		return
 	}

--- a/internal/provider/resource_monitor_smtp.go
+++ b/internal/provider/resource_monitor_smtp.go
@@ -252,6 +252,11 @@ func (r *MonitorSMTPResource) Read(ctx context.Context, req resource.ReadRequest
 		return
 	}
 
+	if smtpMonitor.Base.Type() != smtpMonitor.Type() {
+		resp.State.RemoveResource(ctx)
+		return
+	}
+
 	populateSMTPMonitorFields(&smtpMonitor, &data)
 	populateSMTPOptionalFields(ctx, &smtpMonitor, &data, &resp.Diagnostics)
 

--- a/internal/provider/resource_monitor_smtp.go
+++ b/internal/provider/resource_monitor_smtp.go
@@ -15,6 +15,7 @@ import (
 	"github.com/hashicorp/terraform-plugin-framework/resource/schema/stringdefault"
 	"github.com/hashicorp/terraform-plugin-framework/schema/validator"
 	"github.com/hashicorp/terraform-plugin-framework/types"
+	"github.com/hashicorp/terraform-plugin-log/tflog"
 
 	kuma "github.com/breml/go-uptime-kuma-client"
 	"github.com/breml/go-uptime-kuma-client/monitor"
@@ -252,7 +253,12 @@ func (r *MonitorSMTPResource) Read(ctx context.Context, req resource.ReadRequest
 		return
 	}
 
-	if smtpMonitor.Base.Type() != smtpMonitor.Type() {
+	if actual := smtpMonitor.Base.Type(); actual != "" && actual != smtpMonitor.Type() {
+		tflog.Warn(ctx, "monitor type changed externally, removing from state", map[string]any{
+			"id":            data.ID.ValueInt64(),
+			"expected_type": smtpMonitor.Type(),
+			"actual_type":   actual,
+		})
 		resp.State.RemoveResource(ctx)
 		return
 	}

--- a/internal/provider/resource_monitor_snmp.go
+++ b/internal/provider/resource_monitor_snmp.go
@@ -294,6 +294,11 @@ func (r *MonitorSNMPResource) Read(ctx context.Context, req resource.ReadRequest
 		return
 	}
 
+	if snmpMonitor.Base.Type() != snmpMonitor.Type() {
+		resp.State.RemoveResource(ctx)
+		return
+	}
+
 	populateSNMPMonitorBaseFields(&snmpMonitor, &data)
 	populateOptionalFieldsForSNMP(ctx, &snmpMonitor, &data, &resp.Diagnostics)
 

--- a/internal/provider/resource_monitor_snmp.go
+++ b/internal/provider/resource_monitor_snmp.go
@@ -14,6 +14,7 @@ import (
 	"github.com/hashicorp/terraform-plugin-framework/resource/schema/int64default"
 	"github.com/hashicorp/terraform-plugin-framework/schema/validator"
 	"github.com/hashicorp/terraform-plugin-framework/types"
+	"github.com/hashicorp/terraform-plugin-log/tflog"
 
 	kuma "github.com/breml/go-uptime-kuma-client"
 	"github.com/breml/go-uptime-kuma-client/monitor"
@@ -294,7 +295,12 @@ func (r *MonitorSNMPResource) Read(ctx context.Context, req resource.ReadRequest
 		return
 	}
 
-	if snmpMonitor.Base.Type() != snmpMonitor.Type() {
+	if actual := snmpMonitor.Base.Type(); actual != "" && actual != snmpMonitor.Type() {
+		tflog.Warn(ctx, "monitor type changed externally, removing from state", map[string]any{
+			"id":            data.ID.ValueInt64(),
+			"expected_type": snmpMonitor.Type(),
+			"actual_type":   actual,
+		})
 		resp.State.RemoveResource(ctx)
 		return
 	}

--- a/internal/provider/resource_monitor_sqlserver.go
+++ b/internal/provider/resource_monitor_sqlserver.go
@@ -183,6 +183,11 @@ func (r *MonitorSQLServerResource) Read(
 		return
 	}
 
+	if sqlserverMonitor.Base.Type() != sqlserverMonitor.Type() {
+		resp.State.RemoveResource(ctx)
+		return
+	}
+
 	data.Name = types.StringValue(sqlserverMonitor.Name)
 	if sqlserverMonitor.Description != nil {
 		data.Description = types.StringValue(*sqlserverMonitor.Description)

--- a/internal/provider/resource_monitor_sqlserver.go
+++ b/internal/provider/resource_monitor_sqlserver.go
@@ -10,6 +10,7 @@ import (
 	"github.com/hashicorp/terraform-plugin-framework/resource/schema"
 	"github.com/hashicorp/terraform-plugin-framework/resource/schema/stringdefault"
 	"github.com/hashicorp/terraform-plugin-framework/types"
+	"github.com/hashicorp/terraform-plugin-log/tflog"
 
 	kuma "github.com/breml/go-uptime-kuma-client"
 	"github.com/breml/go-uptime-kuma-client/monitor"
@@ -183,7 +184,12 @@ func (r *MonitorSQLServerResource) Read(
 		return
 	}
 
-	if sqlserverMonitor.Base.Type() != sqlserverMonitor.Type() {
+	if actual := sqlserverMonitor.Base.Type(); actual != "" && actual != sqlserverMonitor.Type() {
+		tflog.Warn(ctx, "monitor type changed externally, removing from state", map[string]any{
+			"id":            data.ID.ValueInt64(),
+			"expected_type": sqlserverMonitor.Type(),
+			"actual_type":   actual,
+		})
 		resp.State.RemoveResource(ctx)
 		return
 	}

--- a/internal/provider/resource_monitor_steam.go
+++ b/internal/provider/resource_monitor_steam.go
@@ -14,6 +14,7 @@ import (
 	"github.com/hashicorp/terraform-plugin-framework/resource/schema/int64default"
 	"github.com/hashicorp/terraform-plugin-framework/schema/validator"
 	"github.com/hashicorp/terraform-plugin-framework/types"
+	"github.com/hashicorp/terraform-plugin-log/tflog"
 
 	kuma "github.com/breml/go-uptime-kuma-client"
 	"github.com/breml/go-uptime-kuma-client/monitor"
@@ -164,7 +165,12 @@ func (r *MonitorSteamResource) Read(ctx context.Context, req resource.ReadReques
 		return
 	}
 
-	if steamMonitor.Base.Type() != steamMonitor.Type() {
+	if actual := steamMonitor.Base.Type(); actual != "" && actual != steamMonitor.Type() {
+		tflog.Warn(ctx, "monitor type changed externally, removing from state", map[string]any{
+			"id":            data.ID.ValueInt64(),
+			"expected_type": steamMonitor.Type(),
+			"actual_type":   actual,
+		})
 		resp.State.RemoveResource(ctx)
 		return
 	}

--- a/internal/provider/resource_monitor_steam.go
+++ b/internal/provider/resource_monitor_steam.go
@@ -164,6 +164,11 @@ func (r *MonitorSteamResource) Read(ctx context.Context, req resource.ReadReques
 		return
 	}
 
+	if steamMonitor.Base.Type() != steamMonitor.Type() {
+		resp.State.RemoveResource(ctx)
+		return
+	}
+
 	populateSteamModel(&steamMonitor, &data)
 	populateSteamOptionalFields(ctx, &steamMonitor, &data, &resp.Diagnostics)
 	if resp.Diagnostics.HasError() {

--- a/internal/provider/resource_monitor_tailscale_ping.go
+++ b/internal/provider/resource_monitor_tailscale_ping.go
@@ -9,6 +9,7 @@ import (
 	"github.com/hashicorp/terraform-plugin-framework/resource"
 	"github.com/hashicorp/terraform-plugin-framework/resource/schema"
 	"github.com/hashicorp/terraform-plugin-framework/types"
+	"github.com/hashicorp/terraform-plugin-log/tflog"
 
 	kuma "github.com/breml/go-uptime-kuma-client"
 	"github.com/breml/go-uptime-kuma-client/monitor"
@@ -173,7 +174,12 @@ func (r *MonitorTailscalePingResource) Read(
 		return
 	}
 
-	if tailscalePingMonitor.Base.Type() != tailscalePingMonitor.Type() {
+	if actual := tailscalePingMonitor.Base.Type(); actual != "" && actual != tailscalePingMonitor.Type() {
+		tflog.Warn(ctx, "monitor type changed externally, removing from state", map[string]any{
+			"id":            data.ID.ValueInt64(),
+			"expected_type": tailscalePingMonitor.Type(),
+			"actual_type":   actual,
+		})
 		resp.State.RemoveResource(ctx)
 		return
 	}

--- a/internal/provider/resource_monitor_tailscale_ping.go
+++ b/internal/provider/resource_monitor_tailscale_ping.go
@@ -173,6 +173,11 @@ func (r *MonitorTailscalePingResource) Read(
 		return
 	}
 
+	if tailscalePingMonitor.Base.Type() != tailscalePingMonitor.Type() {
+		resp.State.RemoveResource(ctx)
+		return
+	}
+
 	data.Name = types.StringValue(tailscalePingMonitor.Name)
 	if tailscalePingMonitor.Description != nil {
 		data.Description = types.StringValue(*tailscalePingMonitor.Description)

--- a/internal/provider/resource_monitor_tcp_port.go
+++ b/internal/provider/resource_monitor_tcp_port.go
@@ -12,6 +12,7 @@ import (
 	"github.com/hashicorp/terraform-plugin-framework/resource/schema"
 	"github.com/hashicorp/terraform-plugin-framework/schema/validator"
 	"github.com/hashicorp/terraform-plugin-framework/types"
+	"github.com/hashicorp/terraform-plugin-log/tflog"
 
 	kuma "github.com/breml/go-uptime-kuma-client"
 	"github.com/breml/go-uptime-kuma-client/monitor"
@@ -184,7 +185,12 @@ func (r *MonitorTCPPortResource) Read(ctx context.Context, req resource.ReadRequ
 		return
 	}
 
-	if tcpPortMonitor.Base.Type() != tcpPortMonitor.Type() {
+	if actual := tcpPortMonitor.Base.Type(); actual != "" && actual != tcpPortMonitor.Type() {
+		tflog.Warn(ctx, "monitor type changed externally, removing from state", map[string]any{
+			"id":            data.ID.ValueInt64(),
+			"expected_type": tcpPortMonitor.Type(),
+			"actual_type":   actual,
+		})
 		resp.State.RemoveResource(ctx)
 		return
 	}

--- a/internal/provider/resource_monitor_tcp_port.go
+++ b/internal/provider/resource_monitor_tcp_port.go
@@ -184,6 +184,11 @@ func (r *MonitorTCPPortResource) Read(ctx context.Context, req resource.ReadRequ
 		return
 	}
 
+	if tcpPortMonitor.Base.Type() != tcpPortMonitor.Type() {
+		resp.State.RemoveResource(ctx)
+		return
+	}
+
 	data.Name = types.StringValue(tcpPortMonitor.Name)
 	if tcpPortMonitor.Description != nil {
 		data.Description = types.StringValue(*tcpPortMonitor.Description)


### PR DESCRIPTION
## Summary

- When a monitor's type is changed outside of Terraform (e.g. via the Uptime Kuma UI), the `Read` function previously reported no diff
- `GetMonitorAs` succeeds regardless of type change because Uptime Kuma preserves all type-specific fields in the database, so JSON unmarshalling populates the target struct without error
- Add a type mismatch check in the `Read` function of all 25 monitor resource types: compare `Base.Type()` (actual API type) against `Type()` (hardcoded expected type per struct); on mismatch, remove the resource from state to force recreation on next apply
- Guard against false-positive removals when `Base.Type` returns `""` (partial/malformed server response) by requiring `actual != ""` before acting on a mismatch
- Add `tflog.Warn` before removal, logging monitor ID, expected type, and actual type so operators can diagnose unexpected re-creates
- Add `TestAccMonitorPingResource_typeDrift` acceptance test covering the full drift detection flow using the existing `outOfBandClient` infrastructure

Closes #330