### PR TITLE
feat(status-page): add url attribute for status page monitors

### DIFF
--- a/docs/resources/status_page.md
+++ b/docs/resources/status_page.md
@@ -34,7 +34,7 @@ resource "uptimekuma_status_page" "example" {
       monitor_list = [
         {
           id       = uptimekuma_monitor_http.example.id
-          send_url = false
+          send_url = true
           url      = "https://example.com"
         }
       ]
@@ -96,4 +96,4 @@ Required:
 Optional:
 
 - `send_url` (Boolean) Include monitor URL in status page
-- `url` (String) Custom URL to use as the clickable link for this monitor on the status page, overriding the monitor's own check URL
+- `url` (String) Custom URL to use as the clickable link for this monitor on the status page, overriding the monitor's own check URL. Only takes effect when `send_url` is also set to `true`

--- a/docs/resources/status_page.md
+++ b/docs/resources/status_page.md
@@ -35,6 +35,7 @@ resource "uptimekuma_status_page" "example" {
         {
           id       = uptimekuma_monitor_http.example.id
           send_url = false
+          url      = "https://example.com"
         }
       ]
     }
@@ -95,3 +96,4 @@ Required:
 Optional:
 
 - `send_url` (Boolean) Include monitor URL in status page
+- `url` (String) Custom URL to use as the clickable link for this monitor on the status page, overriding the monitor's own check URL

--- a/examples/resources/uptimekuma_status_page/resource.tf
+++ b/examples/resources/uptimekuma_status_page/resource.tf
@@ -19,7 +19,7 @@ resource "uptimekuma_status_page" "example" {
       monitor_list = [
         {
           id       = uptimekuma_monitor_http.example.id
-          send_url = false
+          send_url = true
           url      = "https://example.com"
         }
       ]

--- a/examples/resources/uptimekuma_status_page/resource.tf
+++ b/examples/resources/uptimekuma_status_page/resource.tf
@@ -20,6 +20,7 @@ resource "uptimekuma_status_page" "example" {
         {
           id       = uptimekuma_monitor_http.example.id
           send_url = false
+          url      = "https://example.com"
         }
       ]
     }

--- a/go.mod
+++ b/go.mod
@@ -3,7 +3,7 @@ module github.com/breml/terraform-provider-uptimekuma
 go 1.25.8
 
 require (
-	github.com/breml/go-uptime-kuma-client v0.4.1
+	github.com/breml/go-uptime-kuma-client v0.4.2
 	github.com/hashicorp/terraform-plugin-framework v1.19.0
 	github.com/hashicorp/terraform-plugin-go v0.31.0
 	github.com/hashicorp/terraform-plugin-log v0.10.0

--- a/go.sum
+++ b/go.sum
@@ -174,8 +174,8 @@ github.com/breml/errchkjson v0.4.1 h1:keFSS8D7A2T0haP9kzZTi7o26r7kE3vymjZNeNDRDw
 github.com/breml/errchkjson v0.4.1/go.mod h1:a23OvR6Qvcl7DG/Z4o0el6BRAjKnaReoPQFciAl9U3s=
 github.com/breml/githooks v0.0.0-20260421174736-44943ba7a400 h1:cIb+p5+NZWX/LW6mg7bjKRC9CwLSAuT4BTh4myHmAsI=
 github.com/breml/githooks v0.0.0-20260421174736-44943ba7a400/go.mod h1:NMjkJNTWH8yMiZ1m7Gtpm3YdMT28YZoltLEo0mDPqZ0=
-github.com/breml/go-uptime-kuma-client v0.4.1 h1:DqOOrKpqF+Xm6pQivJWkWCQkLHtnkBwQAmIRy4PRS/Y=
-github.com/breml/go-uptime-kuma-client v0.4.1/go.mod h1:rCvWTrKsbBPw79rFFtq5xLZNG48Ejc6iKeAddhtz2jo=
+github.com/breml/go-uptime-kuma-client v0.4.2 h1:9n630BMjethzqh4O5cpps0ilrQYukSV59fln2rEJiYQ=
+github.com/breml/go-uptime-kuma-client v0.4.2/go.mod h1:rCvWTrKsbBPw79rFFtq5xLZNG48Ejc6iKeAddhtz2jo=
 github.com/breml/go.socket.io v0.0.0-20260516193936-e70410c8cd31 h1:l5fVxSzbJHJ1jcLxmcOLVY0uxZFfB1yuztPJVtMfLRg=
 github.com/breml/go.socket.io v0.0.0-20260516193936-e70410c8cd31/go.mod h1:H1EoWDJvqfV2WryM8F9og6ZkH7NsZDlHr0BRkKb58tY=
 github.com/breml/newline-after-block v0.0.0-20251225141726-84337171eef7 h1:ilIWXePccxYq7HvA/max1ZqS0kTkIB/sKzBPDneECts=

--- a/internal/provider/CLAUDE.md
+++ b/internal/provider/CLAUDE.md
@@ -385,6 +385,7 @@ type PublicGroupModel struct {
 type PublicMonitorModel struct {
     ID      types.Int64
     SendURL types.Bool        // Show URL in status page
+    URL     types.String      // Custom clickable URL, overriding the monitor's own check URL
 }
 ```
 

--- a/internal/provider/resource_status_page.go
+++ b/internal/provider/resource_status_page.go
@@ -275,7 +275,8 @@ func (*StatusPageResource) Schema(_ context.Context, _ resource.SchemaRequest, r
 									},
 									"url": schema.StringAttribute{
 										MarkdownDescription: "Custom URL to use as the clickable link for this" +
-											" monitor on the status page, overriding the monitor's own check URL",
+											" monitor on the status page, overriding the monitor's own check URL." +
+											" Only takes effect when `send_url` is also set to `true`",
 										Optional: true,
 									},
 								},
@@ -315,37 +316,9 @@ func (r *StatusPageResource) Create(ctx context.Context, req resource.CreateRequ
 		return
 	}
 
-	// Resolve analytics fields, handling the deprecated google_analytics_id.
-	analyticsType, analyticsID := resolveAnalyticsFields(&data)
-
-	// Build the status page object with all configuration.
-	sp := &statuspage.StatusPage{
-		Slug:                  data.Slug.ValueString(),
-		Title:                 data.Title.ValueString(),
-		Description:           data.Description.ValueString(),
-		Icon:                  data.Icon.ValueString(),
-		Theme:                 data.Theme.ValueString(),
-		Published:             data.Published.ValueBool(),
-		ShowTags:              data.ShowTags.ValueBool(),
-		AnalyticsType:         analyticsType,
-		AnalyticsID:           analyticsID,
-		AnalyticsScriptURL:    data.AnalyticsScriptURL.ValueString(),
-		CustomCSS:             data.CustomCSS.ValueString(),
-		FooterText:            data.FooterText.ValueString(),
-		ShowPoweredBy:         data.ShowPoweredBy.ValueBool(),
-		ShowCertificateExpiry: data.ShowCertificateExpiry.ValueBool(),
-		DomainNameList:        []string{},
-		PublicGroupList:       []statuspage.PublicGroup{},
-	}
-
-	// Populate domain names from configuration.
-	r.populateStatusPageDomainNames(ctx, &data, sp, &resp.Diagnostics)
-	if resp.Diagnostics.HasError() {
-		return
-	}
-
-	// Populate public groups (monitor groupings) from configuration.
-	r.populateStatusPagePublicGroups(ctx, &data, sp, &resp.Diagnostics)
+	// Build the status page object with all configuration, using the same
+	// conversion logic as Update so Create and Update never diverge.
+	sp := buildStatusPageFromModel(ctx, &data, &resp.Diagnostics)
 	if resp.Diagnostics.HasError() {
 		return
 	}
@@ -606,85 +579,6 @@ func (r *StatusPageResource) Delete(ctx context.Context, req resource.DeleteRequ
 	if err != nil {
 		resp.Diagnostics.AddError("failed to delete status page", err.Error())
 		return
-	}
-}
-
-func (*StatusPageResource) populateStatusPageDomainNames(
-	ctx context.Context,
-	data *StatusPageResourceModel,
-	sp *statuspage.StatusPage,
-	diags *diag.Diagnostics,
-) {
-	if !data.DomainNameList.IsNull() {
-		var domainNames []string
-		diags.Append(data.DomainNameList.ElementsAs(ctx, &domainNames, false)...)
-		if !diags.HasError() {
-			sp.DomainNameList = domainNames
-		}
-	}
-}
-
-// populateStatusPagePublicGroups populates the public group list from the resource model.
-func (r *StatusPageResource) populateStatusPagePublicGroups(
-	ctx context.Context,
-	data *StatusPageResourceModel,
-	sp *statuspage.StatusPage,
-	diags *diag.Diagnostics,
-) {
-	if !data.PublicGroupList.IsNull() {
-		var groups []PublicGroupModel
-		diags.Append(data.PublicGroupList.ElementsAs(ctx, &groups, false)...)
-		if diags.HasError() {
-			return
-		}
-
-		sp.PublicGroupList = make([]statuspage.PublicGroup, len(groups))
-		for i, group := range groups {
-			r.populatePublicGroup(ctx, &group, &sp.PublicGroupList[i], diags)
-			if diags.HasError() {
-				return
-			}
-		}
-	}
-}
-
-// populatePublicGroup populates a single public group and its monitors.
-func (*StatusPageResource) populatePublicGroup(
-	ctx context.Context,
-	groupModel *PublicGroupModel,
-	publicGroup *statuspage.PublicGroup,
-	diags *diag.Diagnostics,
-) {
-	publicGroup.Name = groupModel.Name.ValueString()
-	publicGroup.Weight = int(groupModel.Weight.ValueInt64())
-	publicGroup.MonitorList = []statuspage.PublicMonitor{}
-
-	if !groupModel.ID.IsNull() {
-		publicGroup.ID = groupModel.ID.ValueInt64()
-	}
-
-	if !groupModel.MonitorList.IsNull() {
-		var monitors []PublicMonitorModel
-		diags.Append(groupModel.MonitorList.ElementsAs(ctx, &monitors, false)...)
-		if diags.HasError() {
-			return
-		}
-
-		publicGroup.MonitorList = make([]statuspage.PublicMonitor, len(monitors))
-		for j, monitor := range monitors {
-			publicGroup.MonitorList[j] = statuspage.PublicMonitor{
-				ID: monitor.ID.ValueInt64(),
-			}
-			if !monitor.SendURL.IsNull() {
-				sendURL := monitor.SendURL.ValueBool()
-				publicGroup.MonitorList[j].SendURL = &sendURL
-			}
-
-			if !monitor.URL.IsNull() {
-				url := monitor.URL.ValueString()
-				publicGroup.MonitorList[j].URL = &url
-			}
-		}
 	}
 }
 

--- a/internal/provider/resource_status_page.go
+++ b/internal/provider/resource_status_page.go
@@ -124,8 +124,9 @@ type PublicGroupModel struct {
 
 // PublicMonitorModel describes a monitor in a public group.
 type PublicMonitorModel struct {
-	ID      types.Int64 `tfsdk:"id"`
-	SendURL types.Bool  `tfsdk:"send_url"`
+	ID      types.Int64  `tfsdk:"id"`
+	SendURL types.Bool   `tfsdk:"send_url"`
+	URL     types.String `tfsdk:"url"`
 }
 
 // Metadata returns the metadata for the resource.
@@ -271,6 +272,11 @@ func (*StatusPageResource) Schema(_ context.Context, _ resource.SchemaRequest, r
 									"send_url": schema.BoolAttribute{
 										MarkdownDescription: "Include monitor URL in status page",
 										Optional:            true,
+									},
+									"url": schema.StringAttribute{
+										MarkdownDescription: "Custom URL to use as the clickable link for this" +
+											" monitor on the status page, overriding the monitor's own check URL",
+										Optional: true,
 									},
 								},
 							},
@@ -563,6 +569,11 @@ func convertMonitorModelsToAPI(monitors []PublicMonitorModel) []statuspage.Publi
 			sendURL := monitor.SendURL.ValueBool()
 			apiMonitors[j].SendURL = &sendURL
 		}
+
+		if !monitor.URL.IsNull() {
+			url := monitor.URL.ValueString()
+			apiMonitors[j].URL = &url
+		}
 	}
 
 	return apiMonitors
@@ -667,6 +678,11 @@ func (*StatusPageResource) populatePublicGroup(
 			if !monitor.SendURL.IsNull() {
 				sendURL := monitor.SendURL.ValueBool()
 				publicGroup.MonitorList[j].SendURL = &sendURL
+			}
+
+			if !monitor.URL.IsNull() {
+				url := monitor.URL.ValueString()
+				publicGroup.MonitorList[j].URL = &url
 			}
 		}
 	}

--- a/internal/provider/resource_status_page_groupid_test.go
+++ b/internal/provider/resource_status_page_groupid_test.go
@@ -20,7 +20,9 @@ func TestAccStatusPageGroupIDs(t *testing.T) {
 		ProtoV6ProviderFactories: testAccProtoV6ProviderFactories,
 		Steps: []resource.TestStep{
 			{
-				Config:             testAccStatusPageResourceConfigWithMonitors(slug, title, monitorName),
+				Config: testAccStatusPageResourceConfigWithMonitors(
+					slug, title, monitorName, "https://example.com/",
+				),
 				ExpectNonEmptyPlan: false,
 				ConfigStateChecks: []statecheck.StateCheck{
 					// Verify that the server-assigned group ID is populated in state.
@@ -36,7 +38,9 @@ func TestAccStatusPageGroupIDs(t *testing.T) {
 				// UseStateForUnknown plan modifier on public_group_list[].id, Terraform
 				// marks the group ID as (known after apply) on every plan, producing a
 				// perpetual diff.
-				Config:             testAccStatusPageResourceConfigWithMonitors(slug, title, monitorName),
+				Config: testAccStatusPageResourceConfigWithMonitors(
+					slug, title, monitorName, "https://example.com/",
+				),
 				ExpectNonEmptyPlan: false,
 			},
 		},

--- a/internal/provider/resource_status_page_perpetual_diff_test.go
+++ b/internal/provider/resource_status_page_perpetual_diff_test.go
@@ -49,6 +49,12 @@ func TestAccStatusPageNoPerpetualDiff(t *testing.T) {
 					),
 					statecheck.ExpectKnownValue(
 						"uptimekuma_status_page.test",
+						tfjsonpath.New("public_group_list").AtSliceIndex(0).AtMapKey("monitor_list").
+							AtSliceIndex(0).AtMapKey("url"),
+						knownvalue.Null(),
+					),
+					statecheck.ExpectKnownValue(
+						"uptimekuma_status_page.test",
 						tfjsonpath.New("public_group_list").AtSliceIndex(1).AtMapKey("id"),
 						knownvalue.NotNull(),
 					),

--- a/internal/provider/resource_status_page_perpetual_diff_test.go
+++ b/internal/provider/resource_status_page_perpetual_diff_test.go
@@ -12,10 +12,10 @@ import (
 )
 
 // TestAccStatusPageNoPerpetualDiff verifies that re-applying the same config
-// with public_group_list (including explicit send_url=false and weight) does
-// not produce a perpetual diff. This reproduces the remaining issue from #223
-// where the server response omits optional fields, causing state to diverge
-// from config.
+// with public_group_list (including explicit send_url=false, url, and weight)
+// does not produce a perpetual diff. This reproduces the remaining issue from
+// #223 where the server response omits optional fields, causing state to
+// diverge from config.
 func TestAccStatusPageNoPerpetualDiff(t *testing.T) {
 	slug := acctest.RandomWithPrefix("test-nodiff")
 	title := "No Perpetual Diff Test"
@@ -56,6 +56,12 @@ func TestAccStatusPageNoPerpetualDiff(t *testing.T) {
 						"uptimekuma_status_page.test",
 						tfjsonpath.New("public_group_list").AtSliceIndex(1).AtMapKey("name"),
 						knownvalue.StringExact("Services"),
+					),
+					statecheck.ExpectKnownValue(
+						"uptimekuma_status_page.test",
+						tfjsonpath.New("public_group_list").AtSliceIndex(1).AtMapKey("monitor_list").
+							AtSliceIndex(0).AtMapKey("url"),
+						knownvalue.StringExact("https://example.org/"),
 					),
 				},
 			},
@@ -168,6 +174,7 @@ resource "uptimekuma_status_page" "test" {
         {
           id       = uptimekuma_monitor_http.mon2.id
           send_url = false
+          url      = "https://example.org/"
         }
       ]
     }

--- a/internal/provider/resource_status_page_test.go
+++ b/internal/provider/resource_status_page_test.go
@@ -397,6 +397,12 @@ func TestAccStatusPageResourceWithMonitors(t *testing.T) {
 						tfjsonpath.New("title"),
 						knownvalue.StringExact(title),
 					),
+					statecheck.ExpectKnownValue(
+						"uptimekuma_status_page.test",
+						tfjsonpath.New("public_group_list").AtSliceIndex(0).AtMapKey("monitor_list").
+							AtSliceIndex(0).AtMapKey("url"),
+						knownvalue.StringExact("https://example.com/"),
+					),
 				},
 			},
 		},
@@ -407,7 +413,7 @@ func testAccStatusPageResourceConfigWithMonitors(slug string, title string, moni
 	return providerConfig() + fmt.Sprintf(`
 resource "uptimekuma_monitor_http" "test" {
   name = %[3]q
-  url  = "https://example.com"
+  url  = "https://example.com/healthz"
 }
 
 resource "uptimekuma_status_page" "test" {
@@ -423,6 +429,7 @@ resource "uptimekuma_status_page" "test" {
         {
           id       = uptimekuma_monitor_http.test.id
           send_url = false
+          url      = "https://example.com/"
         }
       ]
     }

--- a/internal/provider/resource_status_page_test.go
+++ b/internal/provider/resource_status_page_test.go
@@ -385,7 +385,9 @@ func TestAccStatusPageResourceWithMonitors(t *testing.T) {
 		ProtoV6ProviderFactories: testAccProtoV6ProviderFactories,
 		Steps: []resource.TestStep{
 			{
-				Config: testAccStatusPageResourceConfigWithMonitors(slug, title, monitorName),
+				Config: testAccStatusPageResourceConfigWithMonitors(
+					slug, title, monitorName, "https://example.com/",
+				),
 				ConfigStateChecks: []statecheck.StateCheck{
 					statecheck.ExpectKnownValue(
 						"uptimekuma_status_page.test",
@@ -400,8 +402,29 @@ func TestAccStatusPageResourceWithMonitors(t *testing.T) {
 					statecheck.ExpectKnownValue(
 						"uptimekuma_status_page.test",
 						tfjsonpath.New("public_group_list").AtSliceIndex(0).AtMapKey("monitor_list").
+							AtSliceIndex(0).AtMapKey("send_url"),
+						knownvalue.Bool(true),
+					),
+					statecheck.ExpectKnownValue(
+						"uptimekuma_status_page.test",
+						tfjsonpath.New("public_group_list").AtSliceIndex(0).AtMapKey("monitor_list").
 							AtSliceIndex(0).AtMapKey("url"),
 						knownvalue.StringExact("https://example.com/"),
+					),
+				},
+			},
+			{
+				// Update the custom url on an already-created status page to
+				// exercise the Update code path (as opposed to Create).
+				Config: testAccStatusPageResourceConfigWithMonitors(
+					slug, title, monitorName, "https://example.com/v2",
+				),
+				ConfigStateChecks: []statecheck.StateCheck{
+					statecheck.ExpectKnownValue(
+						"uptimekuma_status_page.test",
+						tfjsonpath.New("public_group_list").AtSliceIndex(0).AtMapKey("monitor_list").
+							AtSliceIndex(0).AtMapKey("url"),
+						knownvalue.StringExact("https://example.com/v2"),
 					),
 				},
 			},
@@ -409,7 +432,7 @@ func TestAccStatusPageResourceWithMonitors(t *testing.T) {
 	})
 }
 
-func testAccStatusPageResourceConfigWithMonitors(slug string, title string, monitorName string) string {
+func testAccStatusPageResourceConfigWithMonitors(slug string, title string, monitorName string, url string) string {
 	return providerConfig() + fmt.Sprintf(`
 resource "uptimekuma_monitor_http" "test" {
   name = %[3]q
@@ -428,12 +451,12 @@ resource "uptimekuma_status_page" "test" {
       monitor_list = [
         {
           id       = uptimekuma_monitor_http.test.id
-          send_url = false
-          url      = "https://example.com/"
+          send_url = true
+          url      = %[4]q
         }
       ]
     }
   ]
 }
-`, slug, title, monitorName)
+`, slug, title, monitorName, url)
 }

--- a/internal/provider/status_page_helpers.go
+++ b/internal/provider/status_page_helpers.go
@@ -65,6 +65,7 @@ func groupListAttrType() types.ObjectType {
 				AttrTypes: map[string]attr.Type{
 					"id":       types.Int64Type,
 					"send_url": types.BoolType,
+					"url":      types.StringType,
 				},
 			}},
 		},


### PR DESCRIPTION
## Summary

- Add an optional `url` field to status page `public_group_list.monitor_list` entries, letting each monitor's status page link be overridden independently of the monitor's own check URL (e.g. a monitor checking `/healthz` but linking visitors to `/`)
- Bumps `github.com/breml/go-uptime-kuma-client` to v0.4.2, which adds `statuspage.PublicMonitor.URL` (wire field `url`) alongside the existing `SendURL`, wired through `SaveStatusPage` the same way
- The Terraform attribute is named `url` (matching the client field and wire protocol), rather than `custom_url` as suggested in the issue text

Closes #384

## Test plan

- [x] `task fmt`
- [x] `task lint`
- [x] `task generate-docs`
- [x] `task test`
- [x] `TF_ACC=1 task testacc` (full suite, including extended `TestAccStatusPageResourceWithMonitors` and `TestAccStatusPageNoPerpetualDiff`)